### PR TITLE
Code and test for import log resource

### DIFF
--- a/import-automation/progress-dashboard-rest/app/resource/import_log.py
+++ b/import-automation/progress-dashboard-rest/app/resource/import_log.py
@@ -20,7 +20,8 @@ Import log resource associated with the endpoint
 from enum import Enum
 import http
 
-from flask_restful import Resource, reqparse
+import flask_restful
+from flask_restful import reqparse
 from google.cloud import datastore
 
 from app import utils
@@ -41,7 +42,7 @@ class LogLevel(Enum):
 LOG_LEVELS = set(level.value for level in LogLevel)
 
 
-class ImportLog(Resource):
+class ImportLog(flask_restful.Resource):
     """API for managing the logs of an attempt specified by its attempt_id
     associated with the endpoint '/import/<string:attempt_id>/logs'.
 

--- a/import-automation/progress-dashboard-rest/app/resource/import_log.py
+++ b/import-automation/progress-dashboard-rest/app/resource/import_log.py
@@ -1,0 +1,110 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Import log resource associated with the endpoint
+'/import/<string:attempt_id>/logs'.
+"""
+
+from enum import Enum
+import http
+
+from flask_restful import Resource, reqparse
+from google.cloud import datastore
+
+from app import utils
+from app.resource import import_attempt
+from app.service import import_attempt_database
+
+
+class LogLevel(Enum):
+    """Allowed log levels of a log.
+
+    The level of a log can only be one of these.
+    """
+    INFO = 'info'
+    WARNING = 'warning'
+    SEVERE = 'severe'
+
+
+LOG_LEVELS = set(level.value for level in LogLevel)
+
+
+class ImportLog(Resource):
+    """API for managing the logs of an attempt specified by its attempt_id
+    associated with the endpoint '/import/<string:attempt_id>/logs'.
+
+    Attributes:
+        database: A database service for storing import attempts
+    """
+    parser = reqparse.RequestParser()
+    required_fields = [('level',), ('message',)]
+    optional_fields = [('time_logged',)]
+    utils.add_required_fields(parser, required_fields)
+    utils.add_optional_fields(parser, optional_fields)
+
+    def __init__(self):
+        """Constructs an ImportLog."""
+        self.database = import_attempt_database.ImportAttemptDatabase()
+
+    def get(self, attempt_id):
+        """Queries the logs of an attempt.
+
+        Args:
+            attempt_id: ID string of the attempt
+
+        Returns:
+            A list of logs of the attempt if successful. Otherwise,
+            (error message, error code).
+        """
+        attempt = self.database.get_by_id(attempt_id)
+        if not attempt:
+            return import_attempt.NOT_FOUND_ERROR, http.HTTPStatus.NOT_FOUND
+        return attempt.get('logs', [])
+
+    def post(self, attempt_id):
+        """Adds a new log to an existing attempt.
+
+        time_logged must be in ISO 8601 format with timezone UTC+0, e.g.
+        "2020-06-30T04:28:53.717569+00:00". If time_logged is not specified,
+        the time at which the request is processed will be used.
+
+        level must be one of the allowed levels defined by LogLevel.
+
+        Args:
+            attempt_id: ID string of the attempt
+
+        Returns:
+            A list of logs of the attempt if successful. Otherwise,
+            (error message, error code).
+        """
+        args = ImportLog.parser.parse_args()
+        if args['level'] not in LOG_LEVELS:
+            return ('Log level {} is not allowed'.format(args['level']),
+                    http.HTTPStatus.FORBIDDEN)
+
+        attempt = self.database.get_by_id(attempt_id)
+        if not attempt:
+            return import_attempt.NOT_FOUND_ERROR, http.HTTPStatus.NOT_FOUND
+        if attempt_id != args.get('attempt_id', attempt_id):
+            return import_attempt.ID_NOT_MATCH_ERROR, http.HTTPStatus.CONFLICT
+
+        args.setdefault('time_logged', utils.utctime())
+        logs = attempt.setdefault('logs', [])
+        log = datastore.Entity(exclude_from_indexes=('message',))
+        log.update(args)
+        logs.append(log)
+        self.database.save(attempt)
+
+        return logs

--- a/import-automation/progress-dashboard-rest/test/test_import_log.py
+++ b/import-automation/progress-dashboard-rest/test/test_import_log.py
@@ -1,0 +1,93 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Tests for import_log.py.
+"""
+
+import unittest
+from unittest import mock
+
+from context import app
+from app.resource import import_attempt, import_log
+from app.service import import_attempt_database_dict
+from app import utils
+
+
+PARSE_ARGS = 'flask_restful.reqparse.RequestParser.parse_args'
+IMPORT_ATTEMPT_DATABASE = 'app.resource.import_attempt' \
+                          '.import_attempt_database.ImportAttemptDatabase'
+
+
+@mock.patch(IMPORT_ATTEMPT_DATABASE,
+            import_attempt_database_dict.ImportAttemptDatabaseDict)
+class ImportLogTest(unittest.TestCase):
+    """Tests for ImportLog."""
+
+    def setUp(self):
+        """Clears the database before every test."""
+        import_attempt_database_dict.ImportAttemptDatabaseDict.reset()
+
+    @mock.patch(PARSE_ARGS)
+    def test_post_then_get(self, parse_args):
+        """Tests that POST adds a log to an attempt."""
+        log_0 = {'level': 'info', 'message': 'first'}
+        log_1 = {
+            'level': 'info', 'message': 'second', 'time_logged': utils.utctime()
+        }
+        parse_args.side_effect = [
+            {'import_name': 'name'}, log_0, log_1
+        ]
+        attempt_api = import_attempt.ImportAttemptByID()
+        attempt_id = '0'
+        attempt_api.put(attempt_id)
+
+        log_api = import_log.ImportLog()
+        log_api.post(attempt_id)
+        log_api.post(attempt_id)
+
+        logs = log_api.get(attempt_id)
+        self.assertEqual(2, len(logs))
+        self.assertIn(log_0, logs)
+        self.assertIn(log_1, logs)
+
+    @mock.patch(PARSE_ARGS)
+    def test_log_level_not_allowed(self, parse_args):
+        """Tests that POST returns FORBIDDEN if the level of the log
+        is not supported by the API."""
+        log = {'level': 'nooooo', 'message': 'message'}
+        parse_args.side_effect = [{'import_name': 'name'}, log]
+        attempt_api = import_attempt.ImportAttemptByID()
+        attempt_api.put('0')
+        log_api = import_log.ImportLog()
+        _, err = log_api.post(log)
+        self.assertEqual(403, err)
+
+    def test_not_found(self):
+        """Tests that querying the logs of an attempt that does not exist
+        returns NOT FOUND."""
+        log_api = import_log.ImportLog()
+        _, err = log_api.get('9999')
+        self.assertEqual(404, err)
+
+    @mock.patch(PARSE_ARGS, lambda self: {'import_name': 'name'})
+    def test_get_empty(self):
+        """Tests that querying the logs of an attempt that does not have any
+        log returns an empty list."""
+        attempt_api = import_attempt.ImportAttemptByID()
+        attempt_id = '0'
+        attempt_api.put(attempt_id)
+        log_api = import_log.ImportLog()
+        logs = log_api.get(attempt_id)
+        self.assertEqual([], logs)


### PR DESCRIPTION
The ImportLog class manages the logs of an import attempt. The endpoint '/import/<string:attempt_id>/logs' is exposed. GET and POST are supported.
- GET retrieves the logs of the attempt identified by the attempt_id
- POST adds a new log to the attempt identified by the attempt_id
