### PR TITLE
Import automation: Cloud Build scripts

### DIFF
--- a/import-automation/cloudbuild/cloudbuild.yaml
+++ b/import-automation/cloudbuild/cloudbuild.yaml
@@ -1,16 +1,16 @@
 steps:
 - name: 'gcr.io/cloud-builders/gcloud'
   entrypoint: 'bash'
-  args: ['import-automation/task.sh']
+  args: ['import-automation/cloudbuild/task.sh']
   env:
-  - 'COMMIT_SHA=$COMMIT_SHA',
-  - 'REPO_NAME=$REPO_NAME',
-  - 'BRANCH_NAME=$BRANCH_NAME',
-  - 'HEAD_BRANCH=$_HEAD_BRANCH',
-  - 'BASE_BRANCH=$_BASE_BRANCH',
+  - 'COMMIT_SHA=$COMMIT_SHA'
+  - 'REPO_NAME=$REPO_NAME'
+  - 'BRANCH_NAME=$BRANCH_NAME'
+  - 'HEAD_BRANCH=$_HEAD_BRANCH'
+  - 'BASE_BRANCH=$_BASE_BRANCH'
   - 'PR_NUMBER=$_PR_NUMBER'
   - 'TASK_LOCATION_ID=$_TASK_LOCATION_ID'
   - 'TASK_QUEUE_NAME=$_TASK_QUEUE_NAME'
   - 'TASK_PROJECT_ID=$_TASK_PROJECT_ID'
-  - 'HANDLER_ENDPOINT=$_HANDLER_ENDPOINT'
+  - 'HANDLER_SERVICE=$_HANDLER_SERVICE'
   - 'HANDLER_URI=$_HANDLER_URI'

--- a/import-automation/cloudbuild/cloudbuild.yaml
+++ b/import-automation/cloudbuild/cloudbuild.yaml
@@ -1,0 +1,16 @@
+steps:
+- name: 'gcr.io/cloud-builders/gcloud'
+  entrypoint: 'bash'
+  args: ['import-automation/task.sh']
+  env:
+  - 'COMMIT_SHA=$COMMIT_SHA',
+  - 'REPO_NAME=$REPO_NAME',
+  - 'BRANCH_NAME=$BRANCH_NAME',
+  - 'HEAD_BRANCH=$_HEAD_BRANCH',
+  - 'BASE_BRANCH=$_BASE_BRANCH',
+  - 'PR_NUMBER=$_PR_NUMBER'
+  - 'TASK_LOCATION_ID=$_TASK_LOCATION_ID'
+  - 'TASK_QUEUE_NAME=$_TASK_QUEUE_NAME'
+  - 'TASK_PROJECT_ID=$_TASK_PROJECT_ID'
+  - 'HANDLER_ENDPOINT=$_HANDLER_ENDPOINT'
+  - 'HANDLER_URI=$_HANDLER_URI'

--- a/import-automation/cloudbuild/cloudbuild.yaml
+++ b/import-automation/cloudbuild/cloudbuild.yaml
@@ -1,4 +1,7 @@
 steps:
+# task.sh is a bash script that installs and runs pip to install dependencies
+# and runs create_task.py to create a Cloud Tasks task that passes information
+# about the commit to the executor.
 - name: 'gcr.io/cloud-builders/gcloud'
   entrypoint: 'bash'
   args: ['import-automation/cloudbuild/task.sh']

--- a/import-automation/cloudbuild/create_task.py
+++ b/import-automation/cloudbuild/create_task.py
@@ -22,7 +22,9 @@ import json
 
 from google.cloud import tasks_v2
 
-
+# These fields must present as environmental variables.
+# PR_NUMBER must be an integer.
+# Otherwise, the script will fail.
 TASK_BODY_FIELDS = [
     'COMMIT_SHA',
     'REPO_NAME',
@@ -100,6 +102,9 @@ def main():
     Creates a Cloud Tasks task that ships information about a GitHub commit
     to the executor.
     """
+    # TASK_PROJECT_ID, TASK_LOCATION_ID, TASK_QUEUE_NAME, HANDLER_SERVICE, and
+    # HANDLER_URI must be present as environmental variables.
+    # Otherwise, the script will fail.
     create_task(
         task_body=create_body(),
         project_id=os.environ['TASK_PROJECT_ID'],

--- a/import-automation/cloudbuild/create_task.py
+++ b/import-automation/cloudbuild/create_task.py
@@ -1,0 +1,116 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Creates a Cloud Tasks task that ships information about a GitHub commit
+to the executor.
+"""
+
+import os
+import json
+
+from google.cloud import tasks_v2
+
+
+TASK_BODY_FIELDS = [
+    'COMMIT_SHA',
+    'REPO_NAME',
+    'BRANCH_NAME',
+    'HEAD_BRANCH',
+    'BASE_BRANCH',
+    'PR_NUMBER'
+]
+
+
+def create_body():
+    """Creates the task body for a Cloud Tasks task.
+
+    Specifically, this function looks for the value of every field defined
+    in TASK_BODY_FIELDS in the environment variables.
+
+    PR_NUMBER is converted to an integer.
+
+    Returns:
+        The task body as a dict.
+    """
+    task_body = {}
+    for field in TASK_BODY_FIELDS:
+        task_body[field] = os.environ[field]
+    task_body['PR_NUMBER'] = int(task_body['PR_NUMBER'])
+    return task_body
+
+
+def create_task(task_body, project_id, location_id, queue_name,
+                max_attempts, service, endpoint):
+    """Creates a Google Cloud Tasks App Engine task.
+
+    The App Engine app that handles the task must be under the same Google
+    Cloud project as the task queue.
+
+    The Cloud Tasks Client will attempt to infer credentials based on
+    host environment. See
+    https://cloud.google.com/docs/authentication/production#finding_credentials_automatically.
+
+    Args:
+        task_body: Request body of the task as a dict that
+            will be serialized into json.
+        project_id: ID of the Google Cloud project as a string.
+        location_id: ID of the location where the task queue is hosted.
+        queue_name: Name of the task queue.
+        max_attempts: Maximum number of times this task will be attempted.
+            max_attempts - 1 is the number of times this task can be retried
+            if the first attempt fails.
+        service: Name of the App Engine service that will handle the task.
+        endpoint: Relative URL of the App Engine task handler endpoint.
+    """
+    client = tasks_v2.CloudTasksClient()
+    parent = client.queue_path(project_id, location_id, queue_name)
+    body = json.dumps(task_body)
+    task = {
+        'app_engine_routing': {
+            'service': service
+        },
+        'app_engine_http_request': {
+            'http_method': 'POST',
+            'relative_uri': endpoint,
+            'body': body.encode(),
+            'headers': {
+                'Content-Type': 'application/json'
+            }
+        },
+        'retry_config': {
+            'max_attempts': max_attempts,
+        }
+    }
+    client.create_task(parent, task)
+
+
+def main():
+    """
+    Creates a Cloud Tasks task that ships information about a GitHub commit
+    to the executor.
+    """
+    task_body = create_body()
+    create_task(
+        task_body=task_body,
+        project_id=os.environ['TASK_PROJECT_ID'],
+        location_id=os.environ['TASK_LOCATION_ID'],
+        queue_name=os.environ['TASK_QUEUE_NAME'],
+        max_attempts=os.environ['TASK_MAX_ATTEMPTS'],
+        service=os.environ['HANDLER_SERVICE'],
+        endpoint=os.environ['HANDLER_URI'])
+
+
+if __name__ == '__main__':
+    main()

--- a/import-automation/cloudbuild/create_task.py
+++ b/import-automation/cloudbuild/create_task.py
@@ -70,6 +70,10 @@ def create_task(task_body, project_id, location_id, queue_name,
         queue_name: Name of the task queue.
         service: Name of the App Engine service that will handle the task.
         endpoint: Relative URL of the App Engine task handler endpoint.
+
+    Returns:
+        The created task as a dict.
+        The CloudTasksClient used to create the task.
     """
     client = tasks_v2.CloudTasksClient()
     parent = client.queue_path(project_id, location_id, queue_name)
@@ -88,6 +92,7 @@ def create_task(task_body, project_id, location_id, queue_name,
         }
     }
     client.create_task(parent, task)
+    return task, client
 
 
 def main():
@@ -95,9 +100,8 @@ def main():
     Creates a Cloud Tasks task that ships information about a GitHub commit
     to the executor.
     """
-    task_body = create_body()
     create_task(
-        task_body=task_body,
+        task_body=create_body(),
         project_id=os.environ['TASK_PROJECT_ID'],
         location_id=os.environ['TASK_LOCATION_ID'],
         queue_name=os.environ['TASK_QUEUE_NAME'],

--- a/import-automation/cloudbuild/create_task.py
+++ b/import-automation/cloudbuild/create_task.py
@@ -52,7 +52,7 @@ def create_body():
 
 
 def create_task(task_body, project_id, location_id, queue_name,
-                max_attempts, service, endpoint):
+                service, endpoint):
     """Creates a Google Cloud Tasks App Engine task.
 
     The App Engine app that handles the task must be under the same Google
@@ -68,9 +68,6 @@ def create_task(task_body, project_id, location_id, queue_name,
         project_id: ID of the Google Cloud project as a string.
         location_id: ID of the location where the task queue is hosted.
         queue_name: Name of the task queue.
-        max_attempts: Maximum number of times this task will be attempted.
-            max_attempts - 1 is the number of times this task can be retried
-            if the first attempt fails.
         service: Name of the App Engine service that will handle the task.
         endpoint: Relative URL of the App Engine task handler endpoint.
     """
@@ -78,19 +75,16 @@ def create_task(task_body, project_id, location_id, queue_name,
     parent = client.queue_path(project_id, location_id, queue_name)
     body = json.dumps(task_body)
     task = {
-        'app_engine_routing': {
-            'service': service
-        },
         'app_engine_http_request': {
+            'app_engine_routing': {
+                'service': service
+            },
             'http_method': 'POST',
             'relative_uri': endpoint,
             'body': body.encode(),
             'headers': {
                 'Content-Type': 'application/json'
             }
-        },
-        'retry_config': {
-            'max_attempts': max_attempts,
         }
     }
     client.create_task(parent, task)
@@ -107,7 +101,6 @@ def main():
         project_id=os.environ['TASK_PROJECT_ID'],
         location_id=os.environ['TASK_LOCATION_ID'],
         queue_name=os.environ['TASK_QUEUE_NAME'],
-        max_attempts=os.environ['TASK_MAX_ATTEMPTS'],
         service=os.environ['HANDLER_SERVICE'],
         endpoint=os.environ['HANDLER_URI'])
 

--- a/import-automation/cloudbuild/requirements.txt
+++ b/import-automation/cloudbuild/requirements.txt
@@ -1,0 +1,1 @@
+google-cloud-tasks

--- a/import-automation/cloudbuild/task.sh
+++ b/import-automation/cloudbuild/task.sh
@@ -1,0 +1,4 @@
+curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+python3 get-pip.py
+python3 -m pip install -r import-automation/requirements.txt
+python3 import-automation/create_app.py

--- a/import-automation/cloudbuild/task.sh
+++ b/import-automation/cloudbuild/task.sh
@@ -1,4 +1,4 @@
 curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
 python3 get-pip.py
-python3 -m pip install -r import-automation/requirements.txt
-python3 import-automation/create_app.py
+python3 -m pip install -r import-automation/cloudbuild/requirements.txt
+python3 import-automation/cloudbuild/create_task.py


### PR DESCRIPTION
This PR includes scripts that would be run by Cloud Build on commits. task.sh is a bash script that installs and runs pip to install dependencies and runs create_task.py to create a Cloud Tasks task that passes information about the commit to the executor.

The scripts have been tested on Cloud Build.