### PR TITLE
This library implements the start of a sharded writer in Go.

### DIFF
--- a/util/README.md
+++ b/util/README.md
@@ -48,6 +48,10 @@ Test coming soon.
 -   `util/geo`: This package contains various mappings between geographic
     identifiers (such as 2-character country codes) and Data Commons IDs.
 
+-   `util/sharding_writer`: This package implements an io.Writer that shard
+    files to a given size boundary to help match Data Common's preference of
+    input files remaining under 100 MB.
+
 Additional libraries coming soon.
 
 ### Testing libraries

--- a/util/sharding_writer/doc.go
+++ b/util/sharding_writer/doc.go
@@ -1,0 +1,77 @@
+/*
+Package sharding_writer implements an io.Writer that can smartly split files
+commonly used in Data Commons imports into comfortable sized pieces.
+
+The Writer implements io.Writer, io.StringWriter, io.ByteWriter, and io.Closer.
+
+The default instance of the writer will use 100 MB as the file size to split on, e.g.,
+
+	w := sharding_writer.NewWriter(filename, extension)
+
+The size of the shards can be specified when creating the writer:
+
+	w := sharding_writer.NewWriter(filename, extension,
+		sharding_writer.ShardSize(1024*1024))  // shard size is in bytes.
+
+The writer has some smarts if the data being written to the file is text or even
+MCF / TMCF files. In these cases the writer will ensure shards don't split in the
+middle of a line or a node definition.
+
+When creating the writer, there are options that can specify the type of data to
+get the smarter behavior.
+
+To ensure lines aren't broken in the middle, use TextDataType option.
+
+	w := sharding_writer.NewWriter(filename, extension,
+		sharding_writer.TextDataType(),
+		sharding_writer.ShardSize(10*1024))
+
+For files of MCF data, specify MCFDataType to ensure files don't split in the middle of a node.
+
+	w := sharding_writer.NewWriter(filename, extension,
+		sharding_writer.MCFDataType())
+
+Note that this package does NOT attempt to balance the shard sizes, it is for
+splitting the writes per the given size boundaries.
+
+To take advantage of the io.StringWriter interface, use the io.WriteString method.
+(io.WriteString takes a Writer, but calls it WriteString method if it has one).
+
+
+Example Usage:
+
+	import "github.com/datacommons/data/util/sharding_writer"
+
+	...
+
+	// Create the sharded writer with ~64kB files.
+	sw := sharding_writer.NewWriter("my_data", "csv",
+		sharding_writer.TextDataType().
+		sharding_writer.ShardSize(64*1024))  // shard size is in bytes.
+
+	// Ensure we close when we are all done.
+	defer sw.Close()
+
+	// CSV writer using our writer.
+	w := csv.NewWriter(sw)
+
+	for _, data := range inputs {
+		// convert inputs into []string
+		...
+
+		if err := w.Write(record); err != nil {
+			log.Fatalln("error writing record to csv:", err)
+		}
+	}
+
+	// Write any buffered data to the underlying writer.
+	w.Flush()
+
+	if err := w.Error(); err != nil {
+		log.Fatal(err)
+	}
+
+	// Now there will be a set of files each ~64kB give or take line length.
+
+*/
+package sharding_writer

--- a/util/sharding_writer/sharding_writer.go
+++ b/util/sharding_writer/sharding_writer.go
@@ -1,0 +1,277 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sharding_writer
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"math"
+	"os"
+	"strings"
+)
+
+const (
+	// DefaultShardSize is 100 MB.
+	DefaultShardSize = 100 * 1024 * 1024
+)
+
+// option is an interface for any type of behavior we want to configure on the
+// Writer. The interface methods are private because we do not support options
+// implemented outside this package.
+type Option interface {
+	set(*Options)
+}
+
+// Options is the set of options for the writer. The type is opaque to allow
+// for future additions and subtractions of supported features.
+type Options struct {
+	shardSize int64
+
+	dataType dataType
+}
+
+// shardSize is a byte count to split on.
+type shardSize int64
+
+// ShardSize returns an option that sets the desired shard size in bytes.
+//
+// If the value is non-positive, then there will be no splitting of output.
+// All data will go in a single file.
+func ShardSize(numBytes int64) Option { return shardSize(numBytes) }
+
+func (x shardSize) set(opts *Options) {
+	opts.shardSize = int64(x)
+}
+
+// dataType is an enum of the different types of writing behavior based
+// on the data expected to be written.
+type dataType int
+
+const (
+	// dataTypeBytes is for plain bytes, no smarts, just split on exact byte count.
+	//
+	// This is the default behavior.
+	dataTypeBytes dataType = iota
+
+	// dataTypeText is for textual values that will wrap on the next newline
+	// that comes after the byte count requested.
+	dataTypeText
+
+	// dataTypeMCF is for textual types that have some structure, and the
+	// shard split will only occur after the line that closes an MCF block.
+	dataTypeMCF
+
+	// TODO(rsned): If there are other formats of data being sharded for writing
+	// that need more smarts, add them here. (E.g., JSON should split on the
+	// close of a complete record so that all file shards can be independently
+	// processed safely.
+)
+
+// BytesDataType configures the writer to treat data as plain bytes.
+func BytesDataType() Option { return dataTypeBytes }
+
+// TextDataType configures the writer to treat data as text, so data
+// shards are split on line breaks and not mid-line.
+func TextDataType() Option { return dataTypeText }
+
+// MCFDataType configures the writer to treat data as MCF/TMCF so record are
+// not split between file shards.
+func MCFDataType() Option { return dataTypeMCF }
+
+func (d dataType) set(opts *Options) {
+	opts.dataType = d
+}
+
+// Writer implements sharded writing, spliting files to be as close to the given
+// byte size as possible. This type implements io.WriterCloser and io.StringWriter.
+//
+// If an error occurs writing to the Writer, no more data will be accepted and all
+// subsequent writes will return the error.
+type Writer struct {
+	basePath  string // full path and file name prefix.
+	extension string // extension with leading period if set.
+	opts      *Options
+
+	currentFile  *os.File // file handle currently being written to.
+	currentShard int      // current shard number.
+	bytesWritten int64    // number of bytes written to current shard [0, shardSize).
+
+	// track if we should be failing all writes going forward.
+	errorTriggered bool
+}
+
+// NewWriter returns a sharding writer for the given name and file extension.
+// If no options are given, the writer defaults to 100 MB shard size, and
+// writing out the data as bytes with no smarts on split points.
+//
+// If multiple values of the same type of option are supplied, only the last
+// one will be have effect. E.g., given []Option{ShardSize(1024), ShardSize(100)},
+// the shard size used will be 100 bytes.
+func NewWriter(basePath, extension string, opts ...Option) io.WriteCloser {
+	w := &Writer{
+		basePath:  basePath,
+		extension: extension,
+
+		opts: &Options{
+			shardSize: DefaultShardSize,
+		},
+	}
+
+	// If the user sets an extension, prepend the period if they didn't
+	// so we can more simply construct the filename.
+	if len(extension) > 0 && !strings.HasPrefix("extension", ".") {
+		w.extension = fmt.Sprintf(".%s", extension)
+	}
+
+	// Check the opts and set any the user has chosen to set explicitly.
+	for _, o := range opts {
+		o.set(w.opts)
+	}
+
+	// If the user specifies an unusable size, default to 'all data'.
+	if w.opts.shardSize <= 0 {
+		// 2^64 bytes in a file ought to be enough for anybody.
+		w.opts.shardSize = math.MaxInt64
+	}
+
+	var err error
+	w.currentFile, err = os.Create(w.currentFileName())
+	if err != nil {
+		log.Fatalf("unable to create sharded file %q", w.currentFileName())
+	}
+	return w
+}
+
+// currentFileName is a helper to format the current filename.
+func (w *Writer) currentFileName() string {
+	// TODO(rsned): Come to a decision on shard number width and padding
+	// that will match what the Python library does.
+	// E.g., %d, %05d, etc.
+	return fmt.Sprintf("%s_%d%s", w.basePath, w.currentShard, w.extension)
+}
+
+// Write writes len(p) bytes from p to the underlying data stream. It returns
+// the number of bytes written from p (0 <= n <= len(p)) and any error encountered
+// that caused the write to stop early.
+func (w *Writer) Write(data []byte) (n int, err error) {
+	if w.errorTriggered {
+		return 0, fmt.Errorf("error occurred during previous writes")
+	}
+
+	var bytesWritten int64
+	for len(data) > 0 {
+		// Check if we need to start a new shard.
+		if w.shardFull() {
+			if err := w.newShard(); err != nil {
+				w.errorTriggered = true
+				return int(bytesWritten), err
+			}
+		}
+		// Figure out how much of the input we can use before sharding.
+		splitPoint := w.opts.shardSize - w.bytesWritten
+
+		// If we don't have enough to fill out the remainder of
+		// the current shard, adjust the cut point.
+		if splitPoint > int64(len(data)) {
+			splitPoint = int64(len(data))
+		}
+
+		n, err = w.currentFile.Write(data[:splitPoint])
+		bytesWritten += int64(n)
+		w.bytesWritten += int64(n)
+		if (err != nil) || int64(n) != splitPoint {
+			w.errorTriggered = true
+			return int(bytesWritten), fmt.Errorf("error writing: %v", err)
+		}
+
+		// Drop the portion written so far.
+		data = data[splitPoint:]
+	}
+
+	return int(bytesWritten), nil
+}
+
+// WriteString writes the contents of the given string. It returns the number n of
+// bytes written from from the string (0 <= n <= len(s)) and any error encountered
+// that caused the write to stop early.
+func (w *Writer) WriteString(s string) (n int, err error) {
+	if w.errorTriggered {
+		return 0, fmt.Errorf("error occurred during previous writes")
+	}
+
+	// track total bytes written in this call, which may be more than shardSize.
+	var bytesWritten int64
+
+	switch w.opts.dataType {
+	case dataTypeBytes:
+		return w.Write([]byte(s))
+	case dataTypeText:
+		// TODO(rsned): Implement
+		return -1, fmt.Errorf("sharded writestring for text not implemented yet.")
+	case dataTypeMCF:
+		// TODO(rsned): Implement
+		return -1, fmt.Errorf("sharded writestring for MCF not implemented yet.")
+	}
+
+	return int(bytesWritten), err
+}
+
+// WriteByte writes a single byte to the underlying data stream. It returns
+// any error encountered that caused the write to fail.
+func (w *Writer) WriteByte(c byte) error {
+	n, err := w.Write([]byte{c})
+	if n != 1 {
+		// err != nil is already caught in Write.
+		w.errorTriggered = true
+	}
+	return err
+}
+
+// Close implements io.Closer interface.
+func (w *Writer) Close() error {
+	return w.currentFile.Close()
+}
+
+// newShard is used to close the existing shard, start a new one, and reset
+// the counters. If an error occurs closing the current file or opening the
+// new file, it is returned.
+func (w *Writer) newShard() error {
+	var err error
+
+	if w.currentFile != nil {
+		if err = w.currentFile.Close(); err != nil {
+			w.errorTriggered = true
+			return err
+		}
+	}
+
+	w.currentShard++
+	w.bytesWritten = 0
+
+	w.currentFile, err = os.Create(w.currentFileName())
+	if err != nil {
+		w.errorTriggered = true
+	}
+	return err
+}
+
+// shardFull reports of the current shard is full.
+func (w *Writer) shardFull() bool {
+	// TODO(rsned): Future enhancement: Allow a +/- 1% leeway so we don't end up
+	// writing out a 100 MB shard and a 1 kB shard when it could all
+	// end up in one file.
+	return (w.opts.shardSize - w.bytesWritten) <= 0
+}

--- a/util/sharding_writer/sharding_writer_test.go
+++ b/util/sharding_writer/sharding_writer_test.go
@@ -1,0 +1,551 @@
+package sharding_writer
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"log"
+	"os"
+	"path"
+	"testing"
+)
+
+var (
+	// tmpDir is picked at start time for tests done during this session.
+	tmpDir string
+)
+
+func init() {
+	var err error
+	tmpDir, err = ioutil.TempDir("", "sharding_writer_test")
+	if err != nil {
+		log.Fatalf("unable to create temporary directory for tests")
+	}
+}
+
+// makeFilename constructs a filename relative to the tmpDir for these tests.
+func makeFilename(pieces ...string) string {
+	return path.Join(append([]string{tmpDir}, pieces...)...)
+}
+
+const (
+	// baseString is ranged over to get the desired length of data.
+	// The string is 73 characters long so it should lead to non-identical
+	// rows when repeated line after line.
+	baseString = `abcdef_ghijkl,mnopqr?stuvwx+yz0123-456789*0ABCDE/FGHIJK:LMNOPQ;RSTUVWXYZ.`
+
+	// TODO(rsned): Add in a test string that includes varying byte width
+	// UTF-8 characters such as:
+	//
+	// 2 byte utf-8
+	// U+00A2       ¢   // currency symbol
+	//
+	// 3 byte utf-8
+	// U+20AC       €   // the Euro
+	//
+	// 4 byte utf-8
+	// U+2070E	𠜎
+	// U+20731	𠜱
+
+)
+
+// generateBytes generates a regular set of characters up to the given
+// number, without newlines or whitespace as a slice of bytes.
+func generateBytes(count int64) []byte {
+	// short circuit requests for negative or 0.
+	if count < 1 {
+		return nil
+	}
+
+	var buf bytes.Buffer
+
+	// If the num bytes is more than the length of the src string, range
+	// until we have written enough whole strings.
+	for i := int64(0); i < (count / int64(len(baseString))); i++ {
+		n, err := buf.WriteString(baseString)
+		if n != len(baseString) || err != nil {
+			fmt.Printf("error writing to buffer, had %d, wrote %d, err: %v",
+				len(baseString), n, err)
+		}
+	}
+
+	// Write out the remaining bytes that are less than a full amount to get
+	// to the amount desired.
+	buf.WriteString(baseString[:count%int64(len(baseString))])
+
+	return buf.Bytes()
+}
+
+func TestGenerateBytes(t *testing.T) {
+	tests := []struct {
+		count int64
+		want  string
+	}{
+		{count: -3, want: ""},
+		{count: 0, want: ""},
+		{count: 1, want: "a"},
+		{count: 2, want: "ab"},
+		{count: 73, want: baseString},
+		{count: 74, want: baseString + baseString[0:1]},
+		{count: 75, want: baseString + baseString[0:2]},
+		{count: 80, want: baseString + baseString[0:7]},
+		{count: 100, want: baseString + baseString[0:27]},
+		{count: 150, want: baseString + baseString + baseString[0:4]},
+	}
+
+	for _, test := range tests {
+		cmpBytes(t, fmt.Sprintf("generateBytes(%d)", test.count), generateBytes(test.count), []byte(test.want))
+	}
+}
+
+// generateLines generates the given number of lines of text using varying line
+// lengths to reduce regularity in the generated data.
+func generateLines(count int64) string {
+	// Short circuit requests for negative or 0.
+	if count < 1 {
+		return ""
+	}
+
+	var buf bytes.Buffer
+	var start, end int64
+	var lenBase = int64(len(baseString))
+
+	// Choose some prime number length lines to reduce convenient line
+	// breaks on round and even numbers.
+	const (
+		shortLine int64 = 47
+		medLine   int64 = 61
+		longLine  int64 = 79
+	)
+
+	for i := int64(0); i < count; i++ {
+		lineLength := shortLine
+		if i%2 == 0 {
+			lineLength = medLine
+		} else if i%7 == 0 {
+			lineLength = longLine
+		}
+
+		end = start + lineLength
+		// If we don't have to wrap, write it out and move on.
+		if end < lenBase {
+			buf.WriteString(baseString[start:end])
+			buf.WriteString("\n")
+			start = end
+			continue
+		}
+		// We need to wrap. Write to the end of the string.
+		buf.WriteString(baseString[start:])
+		// Jump back to the start.
+		start = 0
+		// The end is the remainder from dividing by length.
+		end = end % lenBase
+		buf.WriteString(baseString[start:end])
+		buf.WriteString("\n")
+		start = end
+	}
+	return buf.String()
+}
+
+func TestGenerateLines(t *testing.T) {
+	tests := []struct {
+		count int64
+		want  string
+	}{
+		{count: -7, want: ""},
+		{count: 0, want: ""},
+		{
+			count: 1,
+			want:  "abcdef_ghijkl,mnopqr?stuvwx+yz0123-456789*0ABCDE/FGHIJK:LMNOP\n",
+		},
+		{
+			count: 2,
+			want: `abcdef_ghijkl,mnopqr?stuvwx+yz0123-456789*0ABCDE/FGHIJK:LMNOP
+Q;RSTUVWXYZ.abcdef_ghijkl,mnopqr?stuvwx+yz0123-
+`,
+		},
+		{
+			count: 3,
+			want: `abcdef_ghijkl,mnopqr?stuvwx+yz0123-456789*0ABCDE/FGHIJK:LMNOP
+Q;RSTUVWXYZ.abcdef_ghijkl,mnopqr?stuvwx+yz0123-
+456789*0ABCDE/FGHIJK:LMNOPQ;RSTUVWXYZ.abcdef_ghijkl,mnopqr?st
+`,
+		},
+		{
+			count: 4,
+			want: `abcdef_ghijkl,mnopqr?stuvwx+yz0123-456789*0ABCDE/FGHIJK:LMNOP
+Q;RSTUVWXYZ.abcdef_ghijkl,mnopqr?stuvwx+yz0123-
+456789*0ABCDE/FGHIJK:LMNOPQ;RSTUVWXYZ.abcdef_ghijkl,mnopqr?st
+uvwx+yz0123-456789*0ABCDE/FGHIJK:LMNOPQ;RSTUVWX
+`,
+		},
+		{
+			count: 5,
+			want: `abcdef_ghijkl,mnopqr?stuvwx+yz0123-456789*0ABCDE/FGHIJK:LMNOP
+Q;RSTUVWXYZ.abcdef_ghijkl,mnopqr?stuvwx+yz0123-
+456789*0ABCDE/FGHIJK:LMNOPQ;RSTUVWXYZ.abcdef_ghijkl,mnopqr?st
+uvwx+yz0123-456789*0ABCDE/FGHIJK:LMNOPQ;RSTUVWX
+YZ.abcdef_ghijkl,mnopqr?stuvwx+yz0123-456789*0ABCDE/FGHIJK:LM
+`,
+		},
+	}
+
+	for _, test := range tests {
+		if got := generateLines(test.count); got != test.want {
+			t.Errorf("generateLines(%d) = %q, want %q", test.count, got, test.want)
+		}
+	}
+}
+
+// generateMCF generates a series of MCF definitions with a blank line separator
+// between each entry.
+func generateMCF(count int64) string {
+	// Short circuit requests for negative or 0.
+	if count < 1 {
+		return ""
+	}
+
+	var buf bytes.Buffer
+
+	// TODO(rsned): generate the MCF
+
+	return buf.String()
+}
+
+func TestGenerateMCF(t *testing.T) {
+	tests := []struct {
+		count int64
+		want  string
+	}{
+		{count: -1, want: ""},
+		{count: 0, want: ""},
+		// TODO(rsned): add test cases
+	}
+
+	for _, test := range tests {
+		if got := generateMCF(test.count); got != test.want {
+			t.Errorf("generateMCF(%d) = %q, want %q", test.count, got, test.want)
+		}
+	}
+}
+
+// setup does the creation work for a given test, creating the path it
+// will use for its tests.
+func setup(testPath string) {
+	if err := os.Mkdir(makeFilename(testPath), os.ModeDir|0750); err != nil {
+		log.Fatalf("unable to create working dir for test %q: %v", testPath, err)
+	}
+}
+
+// tearDown cleans up the generated files for the given test.
+func tearDown(testPath string) {
+	if err := os.RemoveAll(makeFilename(testPath)); err != nil {
+		fmt.Printf("unable to clean up for test path %q", testPath)
+	}
+}
+
+func checkExpectedNumShards(t *testing.T, testPath string, numExpected int) {
+	dir, err := os.Open(makeFilename(testPath))
+	if err != nil {
+		t.Errorf("unable to open directory to check shards: %v", err)
+		return
+	}
+
+	fileInfos, err := dir.Readdir(-1)
+	if err != nil {
+		t.Errorf("unable to read directory: %v", err)
+		return
+	}
+
+	if len(fileInfos) != numExpected {
+		t.Errorf("num shards = %v, want %v", len(fileInfos), numExpected)
+	}
+}
+
+func checkFilesSumToInputSize(t *testing.T, testPath string, wantSize int64) {
+	dir, err := os.Open(makeFilename(testPath))
+	if err != nil {
+		t.Errorf("unable to open directory to check shards: %v", err)
+		return
+	}
+
+	fileInfos, err := dir.Readdir(-1)
+	if err != nil {
+		t.Errorf("unable to read directory: %v", err)
+		return
+	}
+
+	var sumSize int64
+	for _, fi := range fileInfos {
+		sumSize += fi.Size()
+	}
+
+	if sumSize != wantSize {
+		t.Errorf("sum of file sizes = %d, want %d", sumSize, wantSize)
+	}
+}
+
+func cmpBytes(t *testing.T, label string, a, b []byte) {
+	if len(a) != len(b) {
+		t.Errorf("bytes not the same length: %v != %v", len(a), len(b))
+	}
+
+	for i, val := range a {
+		if b[i] != val {
+			t.Errorf("%s: slices differ starting at element %d: 0x%x (%s) vs 0x%x (%s)",
+				label, i, val, string(val), b[i], string(b[i]))
+			return
+		}
+	}
+}
+
+// checkFileBeginEndContents checks that a file begins and ends with the expected values.
+func checkFileBeginEndContents(t *testing.T, testPath, filename string, begins, ends []byte) {
+	fn := makeFilename(testPath, filename)
+	contents, err := ioutil.ReadFile(fn)
+	if err != nil {
+		t.Errorf("error reading %q for content checks: %v", fn, err)
+	}
+
+	if len(contents) < len(begins) {
+		t.Errorf("file %q to short to compare with starting bytes %v", fn, begins)
+	}
+	if len(contents) < len(ends) {
+		t.Errorf("file %q to short to compare with ending bytes %v", fn, begins)
+	}
+
+	cmpBytes(t, fn, contents[0:len(begins)], begins)
+	cmpBytes(t, fn, contents[len(contents)-len(ends):], ends)
+}
+
+func TestWriterWrite(t *testing.T) {
+	tests := []struct {
+		label string   // descriptive label of this case
+		path  string   // directory name piece to distinguish test data
+		opts  []Option // selection of opts to set.
+		count int64    // how many we want to generate
+
+		wantNumShards int
+
+		// Check the first and last bytes of the first shard.
+		wantFirstShardBegin string
+		wantFirstShardEnd   string
+
+		// Check the first and last bytes of the last shard.
+		// Note that these are only checked if there is more than one shard.
+		wantLastShardBegin string
+		wantLastShardEnd   string
+	}{
+		{
+			label:               "Write 1 byte to default shard, default opts, byte data",
+			path:                "1_byte_to_default_shard_all_defaults_write",
+			count:               1,
+			wantNumShards:       1,
+			wantFirstShardBegin: "a",
+			wantFirstShardEnd:   "a",
+		},
+		// TODO(rsned): Add more Write([]byte) test cases.
+	}
+
+	for _, test := range tests {
+		setup(test.path)
+		// Create a sharded writer with the options in the test case.
+		w := NewWriter(makeFilename(test.path, "sharded_data"), "dat",
+			test.opts...)
+
+		// Generate data to be written out.
+		data := generateBytes(test.count)
+
+		n, err := w.Write(data)
+		if err != nil {
+			t.Errorf("error writing to the sharding writer: %v", err)
+			// Move on to next case since the remaining checks won't work.
+			continue
+		}
+		if n != len(data) {
+			t.Errorf("num bytes written doesn't match the input. wrote %d, had %d",
+				n, len(data))
+			// Move on to next case since the remaining checks won't work.
+			continue
+		}
+
+		// Close the writer to ensure it's all saved.
+		w.Close()
+
+		// Now perform the various checks of the outputs.
+		checkExpectedNumShards(t, test.path, test.wantNumShards)
+
+		checkFilesSumToInputSize(t, test.path, int64(len(data)))
+
+		// TODO(rsned): If the shard number format changes, change here and below as well.
+
+		// TODO(rsned): If the shard number format changes, change here and below as well.
+		firstFile := "sharded_data_0.dat"
+		checkFileBeginEndContents(t, test.path, firstFile,
+			[]byte(test.wantFirstShardBegin),
+			[]byte(test.wantFirstShardEnd))
+
+		if test.wantNumShards > 1 {
+			lastFile := fmt.Sprintf("sharded_data_%d.dat", test.wantNumShards-1)
+			checkFileBeginEndContents(t, test.path, lastFile,
+				[]byte(test.wantLastShardBegin),
+				[]byte(test.wantLastShardEnd))
+
+		}
+
+		// If you want to debug output or leave the results on disk,
+		// comment out the tearDown call which removes this tests data.
+		tearDown(test.path)
+	}
+}
+
+func TestWriterWriteString(t *testing.T) {
+	tests := []struct {
+		label string   // descriptive label of this case
+		path  string   // directory name piece to distinguish test data
+		opts  []Option // selection of opts to set.
+		count int64    // how many we want to generate
+
+		// what generator to use. Note this can be different
+		// than what the writer is configured to use to test poor choices.
+		dataType dataType
+
+		wantNumShards int
+
+		// Check the first and last bytes/chars of the first shard.
+		wantFirstShardBegin string
+		wantFirstShardEnd   string
+
+		// Check the first and last bytes/chars of the last shard.
+		// Note that these are only checked if there is more than one shard.
+		wantLastShardBegin string
+		wantLastShardEnd   string
+	}{
+		{
+			label:               "Write 1 byte to default shard, default opts, byte data",
+			path:                "1_byte_to_default_shard_all_defaults_writestring",
+			count:               1,
+			dataType:            dataTypeBytes,
+			wantNumShards:       1,
+			wantFirstShardBegin: "a",
+			wantFirstShardEnd:   "a",
+		},
+		{
+			label: "Write 1 byte to 1 shard, byte data",
+			path:  "1_byte_to_1_byte_shard_writestring",
+			opts: []Option{
+				BytesDataType(),
+				ShardSize(1),
+			},
+			dataType:          dataTypeBytes,
+			count:             1,
+			wantNumShards:     1,
+			wantFirstShardEnd: "a",
+		},
+		{
+			label: "Write 256 bytes to 1 shard, byte data",
+			path:  "256_bytes_to_100mb_shard_writestring",
+			opts: []Option{
+				BytesDataType(),
+			},
+			count:               256,
+			dataType:            dataTypeBytes,
+			wantNumShards:       1,
+			wantFirstShardBegin: "abcdef_g",
+			wantFirstShardEnd:   "z0123-45",
+		},
+		{
+			label: "Write 256 bytes to 32-byte shards, byte data",
+			path:  "256_bytes_to_32_byte_shards_writestring",
+			opts: []Option{
+				BytesDataType(),
+				ShardSize(32),
+			},
+			count:               256,
+			dataType:            dataTypeBytes,
+			wantNumShards:       8,
+			wantFirstShardBegin: "abcdef_g",
+			wantFirstShardEnd:   "vwx+yz01",
+			wantLastShardBegin:  "f_ghijkl",
+			wantLastShardEnd:    "z0123-45",
+		},
+		{
+			label: "Write 257 bytes to 11-byte shards, byte data",
+			path:  "257_bytes_to_11_byte_shards_writestring",
+			opts: []Option{
+				BytesDataType(),
+				ShardSize(11),
+			},
+			count:               257,
+			dataType:            dataTypeBytes,
+			wantNumShards:       24,
+			wantFirstShardBegin: "abcdef_g",
+			wantFirstShardEnd:   "def_ghij",
+			wantLastShardBegin:  "-456",
+			wantLastShardEnd:    "-456",
+		},
+
+		// TODO(rsned): Add tests for text based and MCF based data
+		// as those methods get implemented.
+	}
+
+	for _, test := range tests {
+		setup(test.path)
+		// Create a sharded writer with the options in the test case.
+		w := NewWriter(makeFilename(test.path, "sharded_data"), "dat",
+			test.opts...)
+
+		// Generate data to be written out.
+		var data string
+		switch test.dataType {
+		case dataTypeBytes:
+			data = string(generateBytes(test.count))
+		case dataTypeText:
+			data = generateLines(test.count)
+		case dataTypeMCF:
+			data = generateMCF(test.count)
+		}
+
+		// io.WriterString calls an io.Writer's WriteString if the Writer
+		// also implements StringWriter, which we do.
+		n, err := io.WriteString(w, data)
+		if err != nil {
+			t.Errorf("error writing to the sharding writer: %v", err)
+			// Move on to next case since the remaining checks won't work.
+			continue
+		}
+		if n != len(data) {
+			t.Errorf("num bytes written doesn't match the input. wrote %d, had %d",
+				n, len(data))
+			// Move on to next case since the remaining checks won't work.
+			continue
+		}
+
+		// Close the writer to ensure it's all saved.
+		w.Close()
+
+		// Now perform the various checks of the outputs.
+		checkExpectedNumShards(t, test.path, test.wantNumShards)
+
+		checkFilesSumToInputSize(t, test.path, int64(len(data)))
+
+		// TODO(rsned): If the shard number format changes, change here and below as well.
+		firstFile := "sharded_data_0.dat"
+		checkFileBeginEndContents(t, test.path, firstFile,
+			[]byte(test.wantFirstShardBegin),
+			[]byte(test.wantFirstShardEnd))
+
+		if test.wantNumShards > 1 {
+			lastFile := fmt.Sprintf("sharded_data_%d.dat", test.wantNumShards-1)
+			checkFileBeginEndContents(t, test.path, lastFile,
+				[]byte(test.wantLastShardBegin),
+				[]byte(test.wantLastShardEnd))
+
+		}
+
+		// If you want to debug output or leave the results on disk,
+		// comment out the tearDown call which removes this tests data.
+		tearDown(test.path)
+	}
+}


### PR DESCRIPTION
This library implements the start of a sharded writer in Go to generate.files of the desired size for Data Commons imports (100MB).
Adds a variety of tests and test helper methods to make sure a wide selection of test cases can be comprehensively covered.