### PR TITLE
Address pylint warnings.

### DIFF
--- a/util/mcf_template_filler.py
+++ b/util/mcf_template_filler.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-r"""General class to handle filling in MCF templates for StatisticalPopulation and Observation.
+r"""Fill in MCF templates for StatisticalPopulation and Observation.
 
 This library is a wrapper around Python's `format_map` function, except
 it does not require all `{var_string}`s to have a replacement value.
@@ -33,7 +33,7 @@ import re
 import logging
 
 
-class Filler(object):
+class Filler:
     """Helper class for filling in MCF Templates and removing unused PVs."""
 
     def __init__(self, template, required_vars=None):

--- a/util/sharding_writer.py
+++ b/util/sharding_writer.py
@@ -14,7 +14,7 @@
 """General class to shard while writing strings to file."""
 
 
-class ShardingWriter(object):
+class ShardingWriter:
     """Helper class for writing strings to sharded files."""
 
     def __init__(self, base_path, file_extension='mcf', shard_size=104857600):
@@ -25,7 +25,7 @@ class ShardingWriter(object):
         self._nbytes = 0
         self._fptr = None
 
-    def Write(self, data):
+    def write(self, data):
         """Write to current sharded file if the file has not exceeded size limit."""
         if not self._fptr:
             dest_file = '%s_%s.%s' % (self._base_path, self._shard_id,


### PR DESCRIPTION
Change ShardingWriter.Write -> ShardingWriter.write.  No uses were found.