### PR TITLE
Import automation: returning lists of logs directly

### DIFF
--- a/import-automation/progress-dashboard-rest/app/resource/progress_log.py
+++ b/import-automation/progress-dashboard-rest/app/resource/progress_log.py
@@ -117,7 +117,7 @@ class ProgressLogByRunID(ProgressLog):
         if not run:
             return validation.get_not_found_error(_RUN.run_id, run_id)
         log_ids = run.get(_RUN.logs, [])
-        return {_RUN.logs: self.log_database.load_logs(log_ids)}
+        return self.log_database.load_logs(log_ids)
 
 
 class ProgressLogByAttemptID(ProgressLog):
@@ -144,4 +144,4 @@ class ProgressLogByAttemptID(ProgressLog):
             return validation.get_not_found_error(_ATTEMPT.attempt_id,
                                                   attempt_id)
         log_ids = attempt.get(_ATTEMPT.logs, [])
-        return {_ATTEMPT.logs: self.log_database.load_logs(log_ids)}
+        return self.log_database.load_logs(log_ids)

--- a/import-automation/progress-dashboard-rest/test/progress_log_test.py
+++ b/import-automation/progress-dashboard-rest/test/progress_log_test.py
@@ -116,7 +116,7 @@ class ProgressLogListTest(unittest.TestCase):
     def test_progress_log_by_run_id(self):
         """Tests querying the progress logs of a system run by its run_id."""
         expected = [self.logs[1], self.logs[2]]
-        retrieved = self.by_run_id.get(self.runs[0][_RUN.run_id])[_RUN.logs]
+        retrieved = self.by_run_id.get(self.runs[0][_RUN.run_id])
         self.assertEqual(len(expected), len(retrieved))
         for i, log in enumerate(expected):
             self.assertEqual(log[_LOG.log_id], retrieved[i][_LOG.log_id])
@@ -126,7 +126,7 @@ class ProgressLogListTest(unittest.TestCase):
         its attempt_id."""
         expected = [self.logs[0], self.logs[1]]
         retrieved = self.by_attempt_id.get(
-            self.attempts[0][_ATTEMPT.attempt_id])[_ATTEMPT.logs]
+            self.attempts[0][_ATTEMPT.attempt_id])
         self.assertEqual(len(expected), len(retrieved))
         for i, log in enumerate(expected):
             self.assertEqual(log[_LOG.log_id], retrieved[i][_LOG.log_id])


### PR DESCRIPTION
This PR changes the resources for retrieving the logs of a system run or an import attempt to return lists instead of dicts.

Thanks for reviewing.