### PR TITLE
Removing import automation dependencies from the central requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,14 +4,6 @@ pandas
 pylint
 pytest
 yapf
-flask
-flask_restful
-google-cloud-datastore
-google-cloud-logging
-google-cloud-storage
-google-auth
-gunicorn
-psutil
 
 urllib3
 zipp

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ pandas
 pylint
 pytest
 yapf
+frozendict
 
 urllib3
 zipp


### PR DESCRIPTION
psutil is causing the import automation system to fail because it cannot be installed on App Engine. I suggest we use the central requirements file only for imports and let the import automation project use its own requirement files.

```
unable to execute 'x86_64-linux-gnu-gcc': No such file or directory C compiler or Python headers are not installed on this system. 
Try to run: sudo apt-get install gcc python3-dev
```