### PR TITLE
Adding/fixing some manifests

### DIFF
--- a/scripts/covid_tracking_project/historic_state_data/manifest.json
+++ b/scripts/covid_tracking_project/historic_state_data/manifest.json
@@ -17,7 +17,7 @@
                     "node_mcf": "COVIDTracking_States_StatisticalVariables.mcf"
                 }
             ],
-            "cron_schedule": "* * * * *"
+            "cron_schedule": "45 3 * * *"
         }
     ]
 }

--- a/scripts/covid_tracking_project/historic_us_data/manifest.json
+++ b/scripts/covid_tracking_project/historic_us_data/manifest.json
@@ -15,7 +15,7 @@
                     "cleaned_csv": "COVIDTracking_US.csv"
                 }
             ],
-            "cron_schedule": "* * * * *"
+            "cron_schedule": "30 3 * * *"
         }
     ]
 }

--- a/scripts/us_bls/cpi/manifest.json
+++ b/scripts/us_bls/cpi/manifest.json
@@ -1,7 +1,7 @@
 {
     "import_specifications": [
         {
-            "import_name": "USBLS_CPIAllItems",
+            "import_name": "USBLS_CPIAllItemsAverage",
             "curator_emails": [
                 "shijunjie@google.com"
             ],

--- a/scripts/us_bls/cpi/manifest.json
+++ b/scripts/us_bls/cpi/manifest.json
@@ -26,7 +26,7 @@
                     "node_mcf": "cpi_w_1913_2020.mcf"
                 }
             ],
-            "cron_schedule": "15 20 15 * *"
+            "cron_schedule": "15 17 15 * *"
         }
     ]
 }

--- a/scripts/us_bls/cpi/manifest.json
+++ b/scripts/us_bls/cpi/manifest.json
@@ -1,0 +1,32 @@
+{
+    "import_specifications": [
+        {
+            "import_name": "USBLS_CPIAllItems",
+            "curator_emails": [
+                "shijunjie@google.com"
+            ],
+            "provenance_url": "https://www.bls.gov/cpi/",
+            "provenance_description": "U.S. Bureau of Labor Statistics Consumer Price Index",
+            "scripts": [
+                "generate_csv.py"
+            ],
+            "import_inputs": [
+                {
+                    "template_mcf": "c_cpi_u_1999_2020.tmcf",
+                    "cleaned_csv": "c_cpi_u_1999_2020.csv",
+                    "node_mcf": "c_cpi_u_1999_2020.mcf"
+                },
+                {
+                    "template_mcf": "cpi_u_1913_2020.tmcf",
+                    "cleaned_csv": "cpi_u_1913_2020.csv"
+                },
+                {
+                    "template_mcf": "cpi_w_1913_2020.tmcf",
+                    "cleaned_csv": "cpi_w_1913_2020.csv",
+                    "node_mcf": "cpi_w_1913_2020.mcf"
+                }
+            ],
+            "cron_schedule": "15 20 15 * *"
+        }
+    ]
+}

--- a/scripts/us_fed/treasury_constant_maturity_rates/manifest.json
+++ b/scripts/us_fed/treasury_constant_maturity_rates/manifest.json
@@ -17,7 +17,7 @@
                     "node_mcf": "treasury_constant_maturity_rates.mcf"
                 }
             ],
-            "cron_schedule": "15 5 * * *"
+            "cron_schedule": "15 3 * * *"
         }
     ]
 }

--- a/scripts/us_fed/treasury_constant_maturity_rates/manifest.json
+++ b/scripts/us_fed/treasury_constant_maturity_rates/manifest.json
@@ -1,13 +1,12 @@
 {
     "import_specifications": [
         {
-            "import_name": "us_treasury_constant_maturity_rates",
+            "import_name": "USFed_ConstantMaturityRates",
             "curator_emails": [
                 "shijunjie@google.com"
             ],
             "provenance_url": "https://www.federalreserve.gov/releases/h15/",
             "provenance_description": "U.S. Federal Reserve Treasury Nominal and Inflation-Indexed Constant Maturity Series",
-            "start_date": "2000-10-10",
             "scripts": [
                 "generate_csv_and_mcf.py"
             ],
@@ -18,7 +17,7 @@
                     "node_mcf": "treasury_constant_maturity_rates.mcf"
                 }
             ],
-            "cron_schedule": "* * * * *"
+            "cron_schedule": "15 5 * * *"
         }
     ]
 }


### PR DESCRIPTION
Treasury:
“15 3 * * *“ means everyday at 3:15 AM UTC. According to https://www.federalreserve.gov/releases/h15/, “The release is posted daily Monday through Friday at 4:15pm.”, which is 8:15 PM UTC assuming eastern time.

CPI:
"15 17 15 * *" means the 15th of every month at 5:15 PM UTC. According to https://www.bls.gov/schedule/news_release/cpi.htm, the dataset updates at the latest on 14th at 8:30 AM, which converts to 12:30 PM UTC assuming eastern time.

Covid tracking:
“45 3 * * *” means everyday at 3:45 AM UTC. According to https://covidtracking.com/about-data/faq#why-doesnt-your-data-match-what-i-see-on-the-official-covid-19-page-for-my-state, “We update the dataset by hand once a day and release the data between 5pm and 6pm Eastern Time.”, which is 9-10 PM UTC.