### PR TITLE
States GDP: fixing imports & Import automation: fixing function name

### DIFF
--- a/import-automation/executor/local_executor.py
+++ b/import-automation/executor/local_executor.py
@@ -74,7 +74,7 @@ flags.DEFINE_string(name='access_token',
 
 flags.mark_flag_as_required('import_name')
 flags.register_validator('import_name',
-                         import_target.absolute_import_name,
+                         import_target.is_absolute_import_name,
                          message=('--import_name must be of the form '
                                   f'{_IMPORT_NAME_FORM}.'))
 

--- a/scripts/us_bea/states_gdp/import_data_test.py
+++ b/scripts/us_bea/states_gdp/import_data_test.py
@@ -21,8 +21,8 @@ import os
 import unittest
 
 import pandas as pd
-from us_bea.states_gdp import import_data
-from us_bea.states_gdp import import_industry_data_and_gen_mcf
+import import_data
+import import_industry_data_and_gen_mcf
 
 # _MODULE_DIR is the path to where this test is running from.
 _MODULE_DIR = os.path.dirname(__file__)

--- a/scripts/us_bea/states_gdp/import_data_test.py
+++ b/scripts/us_bea/states_gdp/import_data_test.py
@@ -18,11 +18,16 @@
     python3 test_import.py
 """
 import os
+import sys
+
 import unittest
 
 import pandas as pd
-import import_data
-import import_industry_data_and_gen_mcf
+
+# Allows the following module imports to work when running as a script
+sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+from us_bea.states_gdp import import_data
+from us_bea.states_gdp import import_industry_data_and_gen_mcf
 
 # _MODULE_DIR is the path to where this test is running from.
 _MODULE_DIR = os.path.dirname(__file__)

--- a/scripts/us_bea/states_gdp/import_data_test.py
+++ b/scripts/us_bea/states_gdp/import_data_test.py
@@ -25,7 +25,9 @@ import unittest
 import pandas as pd
 
 # Allows the following module imports to work when running as a script
-sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+sys.path.append(
+    os.path.dirname(os.path.dirname(os.path.dirname(
+        os.path.abspath(__file__)))))
 from us_bea.states_gdp import import_data
 from us_bea.states_gdp import import_industry_data_and_gen_mcf
 

--- a/scripts/us_bea/states_gdp/import_industry_data_and_gen_mcf.py
+++ b/scripts/us_bea/states_gdp/import_industry_data_and_gen_mcf.py
@@ -21,11 +21,16 @@ Also generates the MCF nodes for the data schema.
 
     python3 import_industry_data_and_gen_mcf.py
 """
+import os
 import re
+import sys
 
 from absl import app
 import pandas as pd
-import import_data
+
+# Allows the following module import to work when running as a script
+sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+from us_bea.states_gdp import import_data
 
 # Suppress annoying pandas DF copy warnings.
 pd.options.mode.chained_assignment = None  # default='warn'

--- a/scripts/us_bea/states_gdp/import_industry_data_and_gen_mcf.py
+++ b/scripts/us_bea/states_gdp/import_industry_data_and_gen_mcf.py
@@ -29,7 +29,9 @@ from absl import app
 import pandas as pd
 
 # Allows the following module import to work when running as a script
-sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+sys.path.append(
+    os.path.dirname(os.path.dirname(os.path.dirname(
+        os.path.abspath(__file__)))))
 from us_bea.states_gdp import import_data
 
 # Suppress annoying pandas DF copy warnings.

--- a/scripts/us_bea/states_gdp/import_industry_data_and_gen_mcf.py
+++ b/scripts/us_bea/states_gdp/import_industry_data_and_gen_mcf.py
@@ -25,7 +25,7 @@ import re
 
 from absl import app
 import pandas as pd
-from us_bea.states_gdp import import_data
+import import_data
 
 # Suppress annoying pandas DF copy warnings.
 pd.options.mode.chained_assignment = None  # default='warn'


### PR DESCRIPTION
States GDP:
The module imports like `from us_bea.states_gdp import import_data` makes running the script directly fails (`python3 import_data_test.py`), so changing to direct imports.

Import automation:
The function name was not updated when changing `absolute_import_name` to `is_absolute_import_name`.