### PR TITLE
Updates unit tests to include 14 columns

### DIFF
--- a/scripts/google/covid_mobility/tests/test1/data.csv
+++ b/scripts/google/covid_mobility/tests/test1/data.csv
@@ -1,4 +1,4 @@
-country_region_code,country_region,sub_region_1,sub_region_2,iso_3166_2_code,census_fips_code,date,retail_and_recreation_percent_change_from_baseline,grocery_and_pharmacy_percent_change_from_baseline,parks_percent_change_from_baseline,transit_stations_percent_change_from_baseline,workplaces_percent_change_from_baseline,residential_percent_change_from_baseline
-AE,United Arab Emirates,,,,,2020-02-15,0,4,5,0,2,1
-AE,United Arab Emirates,,,,,2020-02-16,,4,4,1,2,1
-AE,United Arab Emirates,,,,,2020-02-17,-1,1,5,,2,1
+country_region_code,country_region,sub_region_1,sub_region_2,metro_area,iso_3166_2_code,census_fips_code,date,retail_and_recreation_percent_change_from_baseline,grocery_and_pharmacy_percent_change_from_baseline,parks_percent_change_from_baseline,transit_stations_percent_change_from_baseline,workplaces_percent_change_from_baseline,residential_percent_change_from_baseline
+AE,United Arab Emirates,,,,,,2020-02-15,0,4,5,0,2,1
+AE,United Arab Emirates,,,,,,2020-02-16,,4,4,1,2,1
+AE,United Arab Emirates,,,,,,2020-02-17,-1,1,5,,2,1

--- a/scripts/google/covid_mobility/tests/test2/data.csv
+++ b/scripts/google/covid_mobility/tests/test2/data.csv
@@ -1,4 +1,4 @@
-country_region_code,country_region,sub_region_1,sub_region_2,iso_3166_2_code,census_fips_code,date,retail_and_recreation_percent_change_from_baseline,grocery_and_pharmacy_percent_change_from_baseline,parks_percent_change_from_baseline,transit_stations_percent_change_from_baseline,workplaces_percent_change_from_baseline,residential_percent_change_from_baseline
-US,United States,Florida,Miami-Dade County,,12086,2020-02-25,1,1,7,0,2,0
-US,United States,Florida,Miami-Dade County,,12086,2020-02-26,,-2,-15,1,2,0
-US,United States,Florida,Miami-Dade County,,12086,2020-02-27,4,5,,-1,2,0
+country_region_code,country_region,sub_region_1,sub_region_2,metro_area,iso_3166_2_code,census_fips_code,date,retail_and_recreation_percent_change_from_baseline,grocery_and_pharmacy_percent_change_from_baseline,parks_percent_change_from_baseline,transit_stations_percent_change_from_baseline,workplaces_percent_change_from_baseline,residential_percent_change_from_baseline
+US,United States,Florida,Miami-Dade County,,,12086,2020-02-25,1,1,7,0,2,0
+US,United States,Florida,Miami-Dade County,,,12086,2020-02-26,,-2,-15,1,2,0
+US,United States,Florida,Miami-Dade County,,,12086,2020-02-27,4,5,,-1,2,0

--- a/scripts/google/covid_mobility/tests/test3/data.csv
+++ b/scripts/google/covid_mobility/tests/test3/data.csv
@@ -1,4 +1,4 @@
-country_region_code,country_region,sub_region_1,sub_region_2,iso_3166_2_code,census_fips_code,date,retail_and_recreation_percent_change_from_baseline,grocery_and_pharmacy_percent_change_from_baseline,parks_percent_change_from_baseline,transit_stations_percent_change_from_baseline,workplaces_percent_change_from_baseline,residential_percent_change_from_baseline
-US,United States,Florida,Miami-Dade County,,12086,2020-02-25,,,,,,
-US,United States,Florida,Miami-Dade County,,12086,2020-02-26,,-2,-15,1,2,0
-US,United States,Florida,Miami-Dade County,,12086,2020-02-27,4,5,,-1,2,0
+country_region_code,country_region,sub_region_1,sub_region_2,metro_area,iso_3166_2_code,census_fips_code,date,retail_and_recreation_percent_change_from_baseline,grocery_and_pharmacy_percent_change_from_baseline,parks_percent_change_from_baseline,transit_stations_percent_change_from_baseline,workplaces_percent_change_from_baseline,residential_percent_change_from_baseline
+US,United States,Florida,Miami-Dade County,,,12086,2020-02-25,,,,,,
+US,United States,Florida,Miami-Dade County,,,12086,2020-02-26,,-2,-15,1,2,0
+US,United States,Florida,Miami-Dade County,,,12086,2020-02-27,4,5,,-1,2,0

--- a/scripts/google/covid_mobility/tests/test4/data.csv
+++ b/scripts/google/covid_mobility/tests/test4/data.csv
@@ -1,4 +1,4 @@
-country_region_code,country_region,sub_region_1,sub_region_2,iso_3166_2_code,census_fips_code,date,retail_and_recreation_percent_change_from_baseline,grocery_and_pharmacy_percent_change_from_baseline,parks_percent_change_from_baseline,transit_stations_percent_change_from_baseline,workplaces_percent_change_from_baseline,residential_percent_change_from_baseline
-US,United States,Florida,Miami-Dade County,,12086,2020-02-26,,-2,-15,1,2,0
-US,United States,Florida,Miami-Dade County,,12086,2020-02-27,4,5,,-1,2,0
-US,United States,Florida,Miami-Dade County,,12086,,1,2,3,-4,5,0
+country_region_code,country_region,sub_region_1,sub_region_2,metro_area,iso_3166_2_code,census_fips_code,date,retail_and_recreation_percent_change_from_baseline,grocery_and_pharmacy_percent_change_from_baseline,parks_percent_change_from_baseline,transit_stations_percent_change_from_baseline,workplaces_percent_change_from_baseline,residential_percent_change_from_baseline
+US,United States,Florida,Miami-Dade County,,,12086,2020-02-26,,-2,-15,1,2,0
+US,United States,Florida,Miami-Dade County,,,12086,2020-02-27,4,5,,-1,2,0
+US,United States,Florida,Miami-Dade County,,,12086,,1,2,3,-4,5,0


### PR DESCRIPTION
The new Covid Mobility CSV includes a new column: metro_area.

The script now has been written to fail if there aren't exactly 14 columns.

This PR adds this extra column to tests so that tests can pass, otherwise they will fail.