### PR TITLE
Quick fix to restore COVID Tracking US data.

### DIFF
--- a/scripts/covid_tracking_project/historic_us_data/preprocess_csv.py
+++ b/scripts/covid_tracking_project/historic_us_data/preprocess_csv.py
@@ -41,15 +41,15 @@ with open('COVIDTracking_US.csv', 'w', newline='') as f_out:
                 ('CumulativeCount_MedicalConditionIncident'
                  '_COVID_19_PatientRecovered'):
                     row_dict['recovered'],
-                ('CumulativeCount_MedicalConditionIncident', '_COVID_19_PatientDeceased'):
+                ('CumulativeCount_MedicalConditionIncident_COVID_19_PatientDeceased'):
                     row_dict['death'],
                 'Count_MedicalConditionIncident_COVID_19_PatientHospitalized':
                     row_dict['hospitalizedCurrently'],
-                ('CumulativeCount_MedicalConditionIncident', '_COVID_19_PatientHospitalized'):
+                ('CumulativeCount_MedicalConditionIncident_COVID_19_PatientHospitalized'):
                     row_dict['hospitalizedCumulative'],
                 'Count_MedicalConditionIncident_COVID_19_PatientInICU':
                     row_dict['inIcuCurrently'],
-                ('CumulativeCount_MedicalConditionIncident', '_COVID_19_PatientInICU'):
+                ('CumulativeCount_MedicalConditionIncident_COVID_19_PatientInICU'):
                     row_dict['inIcuCumulative'],
                 'Count_MedicalConditionIncident_COVID_19_PatientOnVentilator':
                     row_dict['onVentilatorCurrently'],


### PR DESCRIPTION
Quick fix for bug introduced in https://github.com/datacommonsorg/data/commit/3a2b27af8c0eff7085cd0df1f871782cb4812bf7#diff-c03e707a3af1b31f1fed692f3402dea1L43-L51, based on @wh1210 's #262  PR that has some integration test issues.

I ran the script locally and no exceptions. Correctly generated CSV, which I am not updating here (CSV checked into git now matches base cache. This fix is to get branch cache flow up and running again).