### PR TITLE
Make india property countryAlpha2Code instead of isoCode

### DIFF
--- a/scripts/covid19_india/medical_tests_in_data/COVID19_tests_india.tmcf
+++ b/scripts/covid19_india/medical_tests_in_data/COVID19_tests_india.tmcf
@@ -8,4 +8,4 @@ value: C:COVID19_tests_india->CumulativeCount_MedicalTest_ConditionCOVID_19
 
 Node: E:COVID19_tests_india->E1
 typeOf: schema:Country
-isoCode: C:COVID19_tests_india->isoCode
+countryAlpha2Code: C:COVID19_tests_india->isoCode


### PR DESCRIPTION
The property `isoCode` does not exist for India (there are 2 representations of isoCodes for countries, ISO alpha-2 and ISO alpha-3), instead, it is called countryAlpha2Code. https://www.iso.org/iso-3166-country-codes.html