### PR TITLE
Minor tweaks to India RBI Dataset

### DIFF
--- a/scripts/india_rbi/below_poverty_line/BelowPovertyLine_India.tmcf
+++ b/scripts/india_rbi/below_poverty_line/BelowPovertyLine_India.tmcf
@@ -36,7 +36,7 @@ observationAbout: E:BelowPowertyLine_India->E0
 
 Node: E:BelowPowertyLine_India->E5
 typeOf: dcs:StatVarObservation
-variableMeasured: dcs:Count_Person_Rural_BelowPovertyLevelInThePast12Months_AsFractionOf_Count_Person_Urban
+variableMeasured: dcs:Count_Person_Urban_BelowPovertyLevelInThePast12Months_AsFractionOf_Count_Person_Urban
 value: C:BelowPowertyLine_India->percentage_person_urban
 observationDate: C:BelowPowertyLine_India->year
 observationPeriod: "P1Y"
@@ -52,7 +52,7 @@ observationAbout: E:BelowPowertyLine_India->E0
 
 Node: E:BelowPowertyLine_India->E7
 typeOf: dcs:StatVarObservation
-variableMeasured: dcs:ruralPovertyLine
+variableMeasured: dcs:RuralPovertyLine
 value: C:BelowPowertyLine_India->poverty_line_rural
 unit: dcs:IndianRupee
 observationDate: C:BelowPowertyLine_India->year
@@ -61,7 +61,7 @@ observationAbout: E:BelowPowertyLine_India->E0
 
 Node: E:BelowPowertyLine_India->E8
 typeOf: dcs:StatVarObservation
-variableMeasured: dcs:urbanPovertyLine
+variableMeasured: dcs:UrbanPovertyLine
 value: C:BelowPowertyLine_India->poverty_line_urban
 unit: dcs:IndianRupee
 observationDate: C:BelowPowertyLine_India->year

--- a/scripts/india_rbi/below_poverty_line/BelowPovertyLine_India_StatisticalVariables.mcf
+++ b/scripts/india_rbi/below_poverty_line/BelowPovertyLine_India_StatisticalVariables.mcf
@@ -46,3 +46,17 @@ statType: dcs:measuredValue
 measuredProperty: dcs:count
 povertyStatus: dcs:BelowPovertyLevelInThePast12Months
 measurementDenominator: dcid:Count_Person
+
+Node: dcid:RuralPovertyLine
+typeOf: dcs:StatisticalVariable
+populationType: dcs:Person
+placeOfResidence: dcs:Rural
+statType: dcs:measuredValue
+measuredProperty: dcs:povertyLine
+
+Node: dcid:UrbanPovertyLine
+typeOf: dcs:StatisticalVariable
+populationType: dcs:Person
+placeOfResidence: dcs:Urban
+statType: dcs:measuredValue
+measuredProperty: dcs:povertyLine

--- a/scripts/india_rbi/below_poverty_line/preprocess_test.py
+++ b/scripts/india_rbi/below_poverty_line/preprocess_test.py
@@ -29,7 +29,7 @@ class TestPreprocess(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp_dir:
             xlsx_file = os.path.join(module_dir_, 'test_data/test.XLSX')
             expected_file = os.path.join(module_dir_, 'test_data/expected.csv')
-            result_file = os.path.join(tmp_dir, 'test_cleaed.csv')
+            result_file = os.path.join(tmp_dir, 'test_cleaned.csv')
 
             loader = BelowPovertyLineDataLoader(xlsx_file)
             loader.download()


### PR DESCRIPTION
1. A property name for a variable in StatVarObs isn't supported yet in our pipelines. So, for now, add StatVars instead for RuralPovertyLine and UrbanPovertyLine.
2. Fix typo in a StatVar.