### PR TITLE
Add an option to run place-name-resolver without GCS access

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,6 @@ go 1.14
 
 require (
 	cloud.google.com/go/storage v1.10.0 // indirect
+	google.golang.org/grpc v1.29.1 // indirect
 	googlemaps.github.io/maps v1.2.2 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -211,6 +211,7 @@ golang.org/x/sys v0.0.0-20200331124033-c3d80250170d/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200501052902-10377860bb8e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200511232937-7e40ca221e25/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200515095857-1151b9dac4a9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200523222454-059865788121 h1:rITEj+UZHYC927n8GT97eC3zrpzXdb/voyeOuVKS46o=
 golang.org/x/sys v0.0.0-20200523222454-059865788121/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/tools/place_name_resolver/README.md
+++ b/tools/place_name_resolver/README.md
@@ -12,10 +12,20 @@ includes local-id references to contained-in places.
 
 For sample input/output CSVs, see the `.csv` files in `place_name_resolver/testdata` directory.
 
+NOTE: If the `--generate_place_id` is set, then in place of DCIDs, Maps placeIDs
+are returned. This is useful when you cannot access the GCS bucket storing the
+placeID to DCID map.
+
 ## Usage
 
 ```
 go run resolver.go --in_csv_path=testdata/input_basic.csv --out_csv_path=/tmp/output_basic.csv --maps_api_key=<YOUR_KEY_HERE>
+```
+
+For generating place ID:
+
+```
+go run resolver.go --in_csv_path=testdata/input_basic.csv --out_csv_path=/tmp/output_basic.csv --generate_place_id --maps_api_key=<YOUR_KEY_HERE>
 ```
 
 ## Testing

--- a/tools/place_name_resolver/resolver.go
+++ b/tools/place_name_resolver/resolver.go
@@ -21,7 +21,7 @@ var (
 		"literal 'Node' to represent a local ID. containedInPlace is always assumed to be a local reference.")
 	outCsvPath = flag.String("out_csv_path", "", "Same as input with additional column for DCID.")
 	mapsApiKey = flag.String("maps_api_key", "", "Key for accessing Geocoding Maps API.")
-	generatePlaceID = flag.Bool("generate_place_id", false, "If set, this the place ID is generated instead of DCID.")
+	generatePlaceID = flag.Bool("generate_place_id", false, "If set, placeID is generated in output CSV instead of DCID.")
 )
 
 const (

--- a/tools/place_name_resolver/resolver.go
+++ b/tools/place_name_resolver/resolver.go
@@ -187,7 +187,7 @@ func buildTableInfo(inCsvPath string) (*tableInfo, error) {
 	return tinfo, nil
 }
 
-func loadPlaceIdToDcidMap(p2d PlaceId2Dcid, placeId2Dcid *map[string]string) error {
+func loadPlaceIdToDcidMap(p2d PlaceId2Dcid, placeId2Dcid map[string]string) error {
 	bytes, err := p2d.Read()
 	if err != nil {
 		return err
@@ -274,7 +274,7 @@ func resolvePlacesByName(inCsvPath, outCsvPath string, generatePlaceID bool, p2d
 	}
 	placeId2Dcid := map[string]string{}
 	if !generatePlaceID {
-		err = loadPlaceIdToDcidMap(p2d, &placeId2Dcid)
+		err = loadPlaceIdToDcidMap(p2d, placeId2Dcid)
 		if err != nil {
 			return err
 		}

--- a/tools/place_name_resolver/resolver_test.go
+++ b/tools/place_name_resolver/resolver_test.go
@@ -69,7 +69,7 @@ func TestMain(t *testing.T) {
 		{"input_containment.csv", "expected_output_containment.csv", "actual_output_containment.csv", getMockGeocodesContainment()},
 	}
 	for _, t := range table {
-		err := resolvePlacesByName("testdata/"+t.in, "testdata/"+t.got, &MockPlaceId2Dcid{}, t.mapCli)
+		err := resolvePlacesByName("testdata/"+t.in, "testdata/"+t.got, false, &MockPlaceId2Dcid{}, t.mapCli)
 		if err != nil {
 			log.Fatal(err)
 		}


### PR DESCRIPTION
Add a --generate_place_id option to produce placeID results instead of DCID.