### PR TITLE
Fix COVID Tracking MedicalTest stat-var IDs

### DIFF
--- a/scripts/covid_tracking_project/historic_state_data/COVIDTracking_States_StatisticalVariables.mcf
+++ b/scripts/covid_tracking_project/historic_state_data/COVIDTracking_States_StatisticalVariables.mcf
@@ -1,4 +1,4 @@
-Node: dcid:CumulativeCount_MedicalTest_COVID_19
+Node: dcid:CumulativeCount_MedicalTest_ConditionCOVID_19
 typeOf: dcs:StatisticalVariable
 populationType: dcs:MedicalTest
 medicalCondition: dcs:COVID_19
@@ -6,7 +6,7 @@ statType: dcs:measuredValue
 measuredProperty: dcs:cumulativeCount
 testResult: dcs:Ready
 
-Node: dcid:CumulativeCount_MedicalTest_COVID_19_Positive
+Node: dcid:CumulativeCount_MedicalTest_ConditionCOVID_19_Positive
 typeOf: dcs:StatisticalVariable
 populationType: dcs:MedicalTest
 medicalCondition: dcs:COVID_19
@@ -14,7 +14,7 @@ statType: dcs:measuredValue
 measuredProperty: dcs:cumulativeCount
 testResult: dcs:Positive
 
-Node: dcid:CumulativeCount_MedicalTest_COVID_19_Negative
+Node: dcid:CumulativeCount_MedicalTest_ConditionCOVID_19_Negative
 typeOf: dcs:StatisticalVariable
 populationType: dcs:MedicalTest
 medicalCondition: dcs:COVID_19
@@ -22,7 +22,7 @@ statType: dcs:measuredValue
 measuredProperty: dcs:cumulativeCount
 testResult: dcs:Negative
 
-Node: dcid:Count_MedicalTest_COVID_19_Pending
+Node: dcid:Count_MedicalTest_ConditionCOVID_19_Pending
 typeOf: dcs:StatisticalVariable
 populationType: dcs:MedicalTest
 medicalCondition: dcs:COVID_19

--- a/scripts/covid_tracking_project/historic_state_data/preprocess_csv.py
+++ b/scripts/covid_tracking_project/historic_state_data/preprocess_csv.py
@@ -17,10 +17,10 @@ import io
 import urllib.request
 
 output_columns = [
-    'Date', 'GeoId', 'CumulativeCount_MedicalTest_COVID_19',
-    'CumulativeCount_MedicalTest_COVID_19_Positive',
-    'CumulativeCount_MedicalTest_COVID_19_Negative',
-    'Count_MedicalTest_COVID_19_Pending',
+    'Date', 'GeoId', 'CumulativeCount_MedicalTest_ConditionCOVID_19',
+    'CumulativeCount_MedicalTest_ConditionCOVID_19_Positive',
+    'CumulativeCount_MedicalTest_ConditionCOVID_19_Negative',
+    'Count_MedicalTest_ConditionCOVID_19_Pending',
     'CumulativeCount_MedicalConditionIncident_COVID_19_PatientRecovered',
     'CumulativeCount_MedicalConditionIncident_COVID_19_PatientDeceased',
     'Count_MedicalConditionIncident_COVID_19_PatientHospitalized',
@@ -46,13 +46,13 @@ with open('COVIDTracking_States.csv', 'w', newline='') as f_out:
                                   row_dict['date'][6:]),
                 'GeoId':
                     'dcid:geoId/%s' % row_dict['fips'],
-                'CumulativeCount_MedicalTest_COVID_19':
+                'CumulativeCount_MedicalTest_ConditionCOVID_19':
                     row_dict['totalTestResults'],
-                'CumulativeCount_MedicalTest_COVID_19_Positive':
+                'CumulativeCount_MedicalTest_ConditionCOVID_19_Positive':
                     row_dict['positive'],
-                'CumulativeCount_MedicalTest_COVID_19_Negative':
+                'CumulativeCount_MedicalTest_ConditionCOVID_19_Negative':
                     row_dict['negative'],
-                'Count_MedicalTest_COVID_19_Pending':
+                'Count_MedicalTest_ConditionCOVID_19_Pending':
                     row_dict['pending'],
                 ('CumulativeCount_MedicalConditionIncident'
                  '_COVID_19_PatientRecovered'):

--- a/scripts/covid_tracking_project/historic_us_data/preprocess_csv.py
+++ b/scripts/covid_tracking_project/historic_us_data/preprocess_csv.py
@@ -3,10 +3,10 @@ import io
 import urllib.request
 
 output_columns = [
-    'Date', 'CumulativeCount_MedicalTest_COVID_19',
-    'CumulativeCount_MedicalTest_COVID_19_Positive',
-    'CumulativeCount_MedicalTest_COVID_19_Negative',
-    'Count_MedicalTest_COVID_19_Pending',
+    'Date', 'CumulativeCount_MedicalTest_ConditionCOVID_19',
+    'CumulativeCount_MedicalTest_ConditionCOVID_19_Positive',
+    'CumulativeCount_MedicalTest_ConditionCOVID_19_Negative',
+    'Count_MedicalTest_ConditionCOVID_19_Pending',
     'CumulativeCount_MedicalConditionIncident_COVID_19_PatientRecovered',
     'CumulativeCount_MedicalConditionIncident_COVID_19_PatientDeceased',
     'Count_MedicalConditionIncident_COVID_19_PatientHospitalized',
@@ -30,13 +30,13 @@ with open('COVIDTracking_US.csv', 'w', newline='') as f_out:
                 'Date':
                     '%s-%s-%s' % (row_dict['date'][:4], row_dict['date'][4:6],
                                   row_dict['date'][6:]),
-                'CumulativeCount_MedicalTest_COVID_19':
+                'CumulativeCount_MedicalTest_ConditionCOVID_19':
                     row_dict['totalTestResults'],
-                'CumulativeCount_MedicalTest_COVID_19_Positive':
+                'CumulativeCount_MedicalTest_ConditionCOVID_19_Positive':
                     row_dict['positive'],
-                'CumulativeCount_MedicalTest_COVID_19_Negative':
+                'CumulativeCount_MedicalTest_ConditionCOVID_19_Negative':
                     row_dict['negative'],
-                'Count_MedicalTest_COVID_19_Pending':
+                'Count_MedicalTest_ConditionCOVID_19_Pending':
                     row_dict['pending'],
                 ('CumulativeCount_MedicalConditionIncident'
                  '_COVID_19_PatientRecovered'):


### PR DESCRIPTION
Rename the Stat Var IDs to match what is in prod. Previously the same stat-var had a different ID for COVID Tracking.

TESTED=Regenerated the TMCF manually.