### PR TITLE
Auto-assign PRs using Blunderbuss

### DIFF
--- a/.github/blunderbuss.yml
+++ b/.github/blunderbuss.yml
@@ -1,0 +1,2 @@
+assign_prs:
+  - datacommonsorg/core


### PR DESCRIPTION
Use [Blunderbuss](https://github.com/googleapis/repo-automation-bots/tree/master/packages/blunderbuss) to auto-assign PR's to our core team, which is set up to round-robin assign PR's to team members. We can also add a label to auto-assign the backlog of open PR's.