### PR TITLE
Constraint prefix edge case handling and style fixes in statvar_dcid_generator.py

### DIFF
--- a/util/statvar_dcid_generator.py
+++ b/util/statvar_dcid_generator.py
@@ -137,7 +137,7 @@ def _generate_quantity_name(match_dict: dict) -> str:
     return f'{value}{quantity}'
 
 
-def _process_constraint_property(prop, value):
+def _process_constraint_property(prop: str, value: str) -> str:
     """Processes constraint property, value and returns a name that can be used
     in dcid generation.
     Args:

--- a/util/statvar_dcid_generator.py
+++ b/util/statvar_dcid_generator.py
@@ -39,11 +39,14 @@ _DEFAULT_IGNORE_PROPS = ('unit', 'Node', 'memberOf', 'typeOf',
                          'constraintProperties', 'name', 'description',
                          'descriptionUrl', 'label', 'url', 'alternateName')
 
-# Regex to match prefixes to be removed from constraints
-_CONSTRAINT_PREFIX_REGEX = re.compile(r'^(USC|CDC|DAD|BLS|NCES|ACSED)')
+# Regex to match prefixes to be removed from constraints. The regex checks for
+# specific prefixes followed by an upper case letter or underscore. This helps
+# to avoid false positives like 'USCitizenBornInTheUnitedStates'.
+_CONSTRAINT_PREFIX_REGEX = re.compile(
+    r'(?P<prefix>^(USC|CDC|DAD|BLS|NCES|ACSED))(?P<ucase_uscore>[A-Z_])')
 
 
-def _capitalize_process_word(word: str) -> str:
+def _capitalize_process(word: str) -> str:
     """Capitalizes, removes namespaces, measurement constraint prefixes and
     underscores from a word.
 
@@ -65,7 +68,7 @@ def _capitalize_process_word(word: str) -> str:
         word = word[word.find(':') + 1:]
 
         # Removing constraint prefixes
-        word = _CONSTRAINT_PREFIX_REGEX.sub('', word)
+        word = _CONSTRAINT_PREFIX_REGEX.sub(r'\g<ucase_uscore>', word)
 
         # Removing all underscores
         word = word.replace('_', '')
@@ -99,7 +102,7 @@ def _generate_quantity_range_name(match_dict: dict) -> str:
     except KeyError:
         return None
 
-    quantity = _capitalize_process_word(quantity)
+    quantity = _capitalize_process(quantity)
     if upper_limit == '-':
         return f'{lower_limit}OrMore{quantity}'
 
@@ -130,11 +133,38 @@ def _generate_quantity_name(match_dict: dict) -> str:
     except KeyError:
         return None
 
-    quantity = _capitalize_process_word(quantity)
+    quantity = _capitalize_process(quantity)
     return f'{value}{quantity}'
 
 
-def get_stat_var_dcid(stat_var_dict: dict, ignore_props: list = None) -> str:
+def _process_constraint_property(prop, value):
+    """Processes constraint property, value and returns a name that can be used
+    in dcid generation.
+    Args:
+        prop: A string literal representing the constraint property name.
+        value: A string literal representing the constraint property value.
+    Returns:
+        A string that can be used in dcid generation.
+    """
+    match1 = _QUANTITY_RANGE_REGEX_1.match(value)
+    match2 = _QUANTITY_RANGE_REGEX_2.match(value)
+
+    if match1 or match2:  # Quantity Range
+        m_dict = match1.groupdict() if match1 else match2.groupdict()
+        name = _generate_quantity_range_name(m_dict)
+    else:
+        match1 = _QUANTITY_REGEX_1.match(value)
+        match2 = _QUANTITY_REGEX_2.match(value)
+        if match1 or match2:  # Quantity
+            m_dict = match1.groupdict() if match1 else match2.groupdict()
+            name = _generate_quantity_name(m_dict)
+        else:
+            name = _capitalize_process(value)
+
+    return name
+
+
+def get_statvar_dcid(stat_var_dict: dict, ignore_props: list = None) -> str:
     """Generates the dcid given a statistical variable.
 
     Args:
@@ -172,7 +202,7 @@ def get_stat_var_dcid(stat_var_dict: dict, ignore_props: list = None) -> str:
     # Helper function to add a property to the dcid list.
     def add_prop_to_list(prop: str, svd: dict, dcid_list: list):
         if prop in svd:
-            token = _capitalize_process_word(svd[prop])
+            token = _capitalize_process(svd[prop])
             if token is not None:
                 dcid_list.append(token)
             svd.pop(prop, None)
@@ -212,7 +242,7 @@ def get_stat_var_dcid(stat_var_dict: dict, ignore_props: list = None) -> str:
         # MD that are properties (camelCase) are added as Per(MD)
         # An example would be the property 'area' in Count_Person_PerArea
         elif md[0].islower():
-            denominator_suffix = 'Per' + _capitalize_process_word(md)
+            denominator_suffix = 'Per' + _capitalize_process(md)
         # Everything else is AsAFractionOf
         else:
             denominator_suffix = 'AsAFractionOf_' + md
@@ -221,21 +251,8 @@ def get_stat_var_dcid(stat_var_dict: dict, ignore_props: list = None) -> str:
     # Adding constraint properties in alphabetical order
     constraint_props = sorted(svd.keys(), key=str.casefold)
     for prop in constraint_props:
-        match1 = _QUANTITY_RANGE_REGEX_1.match(svd[prop])
-        match2 = _QUANTITY_RANGE_REGEX_2.match(svd[prop])
-        if match1 or match2:
-            m_dict = match1.groupdict() if match1 else match2.groupdict()
-            q_name = _generate_quantity_range_name(m_dict)
-            dcid_list.append(q_name)
-        else:
-            match1 = _QUANTITY_REGEX_1.match(svd[prop])
-            match2 = _QUANTITY_REGEX_2.match(svd[prop])
-            if match1 or match2:
-                m_dict = match1.groupdict() if match1 else match2.groupdict()
-                q_name = _generate_quantity_name(m_dict)
-                dcid_list.append(q_name)
-            else:
-                add_prop_to_list(prop, svd, dcid_list)
+        name = _process_constraint_property(prop, svd[prop])
+        dcid_list.append(name)
 
     if denominator_suffix:
         dcid_list.append(denominator_suffix)

--- a/util/statvar_dcid_generator_test.py
+++ b/util/statvar_dcid_generator_test.py
@@ -24,7 +24,7 @@ from util import statvar_dcid_generator
 class TestStatVarDcidGenerator(unittest.TestCase):
 
     def test_ignore_props(self):
-        stat_var_dict = {
+        statvar_dict = {
             'typeOf': 'StatisticalVariable',
             'statType': 'medianValue',
             'measuredProperty': 'income',
@@ -34,24 +34,24 @@ class TestStatVarDcidGenerator(unittest.TestCase):
         }
         ignore_props = ['age', 'incomeStatus']
         dcid = statvar_dcid_generator.get_statvar_dcid(
-            stat_var_dict, ignore_props=ignore_props)
+            statvar_dict, ignore_props=ignore_props)
         expected_dcid = 'Median_Income_Person'
         self.assertEqual(dcid, expected_dcid)
 
     def test_namespace_removal(self):
-        stat_var_dict = {
+        statvar_dict = {
             'typeOf': 'StatisticalVariable',
             'statType': 'dcs:medianValue',
             'measuredProperty': 'dcid:age',
             'populationType': 'Person',
             'nativity': 'USC_Native',
         }
-        dcid = statvar_dcid_generator.get_statvar_dcid(stat_var_dict)
+        dcid = statvar_dcid_generator.get_statvar_dcid(statvar_dict)
         expected_dcid = 'Median_Age_Person_Native'
         self.assertEqual(dcid, expected_dcid)
 
     def test_measurement_constraint_removal(self):
-        stat_var_dict1 = {
+        statvar_dict1 = {
             'typeOf': 'StatisticalVariable',
             'statType': 'measuredValue',
             'measuredProperty': 'count',
@@ -59,107 +59,107 @@ class TestStatVarDcidGenerator(unittest.TestCase):
             'race': 'USC_AsianAlone',
             'schoolGradeLevel': 'NCESThirdGrade',
         }
-        dcid = statvar_dcid_generator.get_statvar_dcid(stat_var_dict1)
+        dcid = statvar_dcid_generator.get_statvar_dcid(statvar_dict1)
         expected_dcid = 'Count_Student_AsianAlone_ThirdGrade'
         self.assertEqual(dcid, expected_dcid)
 
-        stat_var_dict2 = {
+        statvar_dict2 = {
             'typeOf': 'StatisticalVariable',
             'statType': 'dcs:measuredValue',
             'measuredProperty': 'dcid:count',
             'populationType': 'Person',
             'citizenship': 'dcid:USCitizenBornInTheUnitedStates',
         }
-        dcid = statvar_dcid_generator.get_statvar_dcid(stat_var_dict2)
+        dcid = statvar_dcid_generator.get_statvar_dcid(statvar_dict2)
         expected_dcid = 'Count_Person_USCitizenBornInTheUnitedStates'
         self.assertEqual(dcid, expected_dcid)
 
     def test_quantity_name_generation(self):
-        stat_var_dict1 = {
+        statvar_dict1 = {
             'statType': 'dcs:measuredValue',
             'measuredProperty': 'count',
             'populationType': 'Person',
             'gender': 'Female',
             'age': '[20 Years]'
         }
-        dcid = statvar_dcid_generator.get_statvar_dcid(stat_var_dict1)
+        dcid = statvar_dcid_generator.get_statvar_dcid(statvar_dict1)
         expected_dcid = 'Count_Person_20Years_Female'
         self.assertEqual(dcid, expected_dcid)
 
-        stat_var_dict2 = {
+        statvar_dict2 = {
             'statType': 'dcs:measuredValue',
             'measuredProperty': 'count',
             'populationType': 'Person',
             'gender': 'Female',
             'age': '[Years 20]'
         }
-        dcid = statvar_dcid_generator.get_statvar_dcid(stat_var_dict2)
+        dcid = statvar_dcid_generator.get_statvar_dcid(statvar_dict2)
         expected_dcid = 'Count_Person_20Years_Female'
         self.assertEqual(dcid, expected_dcid)
 
     def test_quantity_range_name_generation(self):
-        stat_var_dict1 = {
+        statvar_dict1 = {
             'statType': 'measuredValue',
             'measuredProperty': 'count',
             'populationType': 'HousingUnit',
             'numberOfRooms': '[9 - Rooms]',
         }
-        dcid = statvar_dcid_generator.get_statvar_dcid(stat_var_dict1)
+        dcid = statvar_dcid_generator.get_statvar_dcid(statvar_dict1)
         expected_dcid = 'Count_HousingUnit_9OrMoreRooms'
         self.assertEqual(dcid, expected_dcid)
 
-        stat_var_dict2 = {
+        statvar_dict2 = {
             'statType': 'measuredValue',
             'measuredProperty': 'count',
             'populationType': 'HousingUnit',
             'numberOfRooms': '[Rooms 9 -]',
         }
-        dcid = statvar_dcid_generator.get_statvar_dcid(stat_var_dict2)
+        dcid = statvar_dcid_generator.get_statvar_dcid(statvar_dict2)
         expected_dcid = 'Count_HousingUnit_9OrMoreRooms'
         self.assertEqual(dcid, expected_dcid)
 
-        stat_var_dict3 = {
+        statvar_dict3 = {
             'statType': 'measuredValue',
             'measuredProperty': 'count',
             'populationType': 'Household',
             'householdWorkerSize': '[- 3 Worker]',
         }
-        dcid = statvar_dcid_generator.get_statvar_dcid(stat_var_dict3)
+        dcid = statvar_dcid_generator.get_statvar_dcid(statvar_dict3)
         expected_dcid = 'Count_Household_3OrLessWorker'
         self.assertEqual(dcid, expected_dcid)
 
-        stat_var_dict4 = {
+        statvar_dict4 = {
             'statType': 'measuredValue',
             'measuredProperty': 'count',
             'populationType': 'Household',
             'householdWorkerSize': '[Worker - 3]',
         }
-        dcid = statvar_dcid_generator.get_statvar_dcid(stat_var_dict4)
+        dcid = statvar_dcid_generator.get_statvar_dcid(statvar_dict4)
         expected_dcid = 'Count_Household_3OrLessWorker'
         self.assertEqual(dcid, expected_dcid)
 
-        stat_var_dict5 = {
+        statvar_dict5 = {
             'statType': 'measuredValue',
             'measuredProperty': 'count',
             'populationType': 'Person',
             'income': '[10000 14999 USDollar]',
         }
-        dcid = statvar_dcid_generator.get_statvar_dcid(stat_var_dict5)
+        dcid = statvar_dcid_generator.get_statvar_dcid(statvar_dict5)
         expected_dcid = 'Count_Person_10000To14999USDollar'
         self.assertEqual(dcid, expected_dcid)
 
-        stat_var_dict6 = {
+        statvar_dict6 = {
             'statType': 'measuredValue',
             'measuredProperty': 'count',
             'populationType': 'Person',
             'income': '[USDollar 10000 14999]',
         }
-        dcid = statvar_dcid_generator.get_statvar_dcid(stat_var_dict6)
+        dcid = statvar_dcid_generator.get_statvar_dcid(statvar_dict6)
         expected_dcid = 'Count_Person_10000To14999USDollar'
         self.assertEqual(dcid, expected_dcid)
 
     def test_sorted_constraints(self):
-        stat_var_dict = {
+        statvar_dict = {
             'statType': 'measuredValue',
             'measuredProperty': 'count',
             'populationType': 'Person',
@@ -167,13 +167,13 @@ class TestStatVarDcidGenerator(unittest.TestCase):
             'educationalAttainment': 'BachelorsDegreeOrHigher',
             'race': 'AsianAlone',
         }
-        dcid = statvar_dcid_generator.get_statvar_dcid(stat_var_dict)
+        dcid = statvar_dcid_generator.get_statvar_dcid(statvar_dict)
         expected_dcid = ('Count_Person_25OrMoreYears_BachelorsDegreeOrHigher'
                          '_AsianAlone')
         self.assertEqual(dcid, expected_dcid)
 
     def test_stat_type(self):
-        stat_var_dict1 = {
+        statvar_dict1 = {
             'measuredProperty': 'dcid:count',
             'statType': 'dcid:marginOfError',
             'populationType': 'dcid:Person',
@@ -181,68 +181,68 @@ class TestStatVarDcidGenerator(unittest.TestCase):
             'healthInsurance': 'dcid:NoHealthInsurance',
             'typeOf': 'dcs:StatisticalVariable'
         }
-        dcid = statvar_dcid_generator.get_statvar_dcid(stat_var_dict1)
+        dcid = statvar_dcid_generator.get_statvar_dcid(statvar_dict1)
         expected_dcid = ('MarginOfError_Count_Person_NoHealthInsurance_'
                          '1To1.49RatioToPovertyLine')
         self.assertEqual(dcid, expected_dcid)
 
-        stat_var_dict2 = {
+        statvar_dict2 = {
             'measuredProperty': 'concentration',
             'statType': 'meanValue',
             'populationType': 'Atmosphere',
             'pollutant': 'PM2.5'
         }
-        dcid = statvar_dcid_generator.get_statvar_dcid(stat_var_dict2)
+        dcid = statvar_dcid_generator.get_statvar_dcid(statvar_dict2)
         expected_dcid = 'Mean_Concentration_Atmosphere_PM2.5'
         self.assertEqual(dcid, expected_dcid)
 
     def test_measured_property(self):
-        stat_var_dict = {
+        statvar_dict = {
             'statType': 'meanValue',
             'measuredProperty': 'wagesDaily',
             'populationType': 'Person',
             'placeOfResidenceClassification': 'Urban'
         }
-        dcid = statvar_dcid_generator.get_statvar_dcid(stat_var_dict)
+        dcid = statvar_dcid_generator.get_statvar_dcid(statvar_dict)
         expected_dcid = 'Mean_WagesDaily_Person_Urban'
         self.assertEqual(dcid, expected_dcid)
 
     def test_measurement_qualifier(self):
-        stat_var_dict = {
+        statvar_dict = {
             'statType': 'measuredValue',
             'measuredProperty': 'precipitationRate',
             'populationType': 'Place',
             'memberOf': 'Climate',
             'measurementQualifier': 'Daily'
         }
-        dcid = statvar_dcid_generator.get_statvar_dcid(stat_var_dict)
+        dcid = statvar_dcid_generator.get_statvar_dcid(statvar_dict)
         expected_dcid = 'Daily_PrecipitationRate_Place'
         self.assertEqual(dcid, expected_dcid)
 
     def test_measurement_denominator(self):
-        stat_var_dict1 = {
+        statvar_dict1 = {
             'statType': 'measuredValue',
             'measuredProperty': 'amount',
             'populationType': 'Consumption',
             'consumedThing': 'Electricity',
             'measurementDenominator': 'PerCapita'
         }
-        dcid = statvar_dcid_generator.get_statvar_dcid(stat_var_dict1)
+        dcid = statvar_dcid_generator.get_statvar_dcid(statvar_dict1)
         expected_dcid = 'Amount_Consumption_Electricity_PerCapita'
         self.assertEqual(dcid, expected_dcid)
 
-        stat_var_dict2 = {
+        statvar_dict2 = {
             'statType': 'measuredValue',
             'measuredProperty': 'count',
             'populationType': 'Person',
             'memberOf': 'Demographics',
             'measurementDenominator': 'area'
         }
-        dcid = statvar_dcid_generator.get_statvar_dcid(stat_var_dict2)
+        dcid = statvar_dcid_generator.get_statvar_dcid(statvar_dict2)
         expected_dcid = 'Count_Person_PerArea'
         self.assertEqual(dcid, expected_dcid)
 
-        stat_var_dict3 = {
+        statvar_dict3 = {
             'statType': 'measuredValue',
             'measuredProperty': 'count',
             'populationType': 'Person',
@@ -250,7 +250,7 @@ class TestStatVarDcidGenerator(unittest.TestCase):
             'educationalAttainment': 'TertiaryEducation',
             'measurementDenominator': 'Count_Person_25To64Years'
         }
-        dcid = statvar_dcid_generator.get_statvar_dcid(stat_var_dict3)
+        dcid = statvar_dcid_generator.get_statvar_dcid(statvar_dict3)
         expected_dcid = ('Count_Person_25To64Years_TertiaryEducation'
                          '_AsAFractionOf_Count_Person_25To64Years')
         self.assertEqual(dcid, expected_dcid)

--- a/util/statvar_dcid_generator_test.py
+++ b/util/statvar_dcid_generator_test.py
@@ -33,9 +33,9 @@ class TestStatVarDcidGenerator(unittest.TestCase):
             'incomeStatus': 'WithIncome'
         }
         ignore_props = ['age', 'incomeStatus']
-        dcid = statvar_dcid_generator.get_stat_var_dcid(
+        dcid = statvar_dcid_generator.get_statvar_dcid(
             stat_var_dict, ignore_props=ignore_props)
-        expected_dcid = ('Median_Income_Person')
+        expected_dcid = 'Median_Income_Person'
         self.assertEqual(dcid, expected_dcid)
 
     def test_namespace_removal(self):
@@ -46,12 +46,12 @@ class TestStatVarDcidGenerator(unittest.TestCase):
             'populationType': 'Person',
             'nativity': 'USC_Native',
         }
-        dcid = statvar_dcid_generator.get_stat_var_dcid(stat_var_dict)
+        dcid = statvar_dcid_generator.get_statvar_dcid(stat_var_dict)
         expected_dcid = 'Median_Age_Person_Native'
         self.assertEqual(dcid, expected_dcid)
 
     def test_measurement_constraint_removal(self):
-        stat_var_dict = {
+        stat_var_dict1 = {
             'typeOf': 'StatisticalVariable',
             'statType': 'measuredValue',
             'measuredProperty': 'count',
@@ -59,8 +59,19 @@ class TestStatVarDcidGenerator(unittest.TestCase):
             'race': 'USC_AsianAlone',
             'schoolGradeLevel': 'NCESThirdGrade',
         }
-        dcid = statvar_dcid_generator.get_stat_var_dcid(stat_var_dict)
+        dcid = statvar_dcid_generator.get_statvar_dcid(stat_var_dict1)
         expected_dcid = 'Count_Student_AsianAlone_ThirdGrade'
+        self.assertEqual(dcid, expected_dcid)
+
+        stat_var_dict2 = {
+            'typeOf': 'StatisticalVariable',
+            'statType': 'dcs:measuredValue',
+            'measuredProperty': 'dcid:count',
+            'populationType': 'Person',
+            'citizenship': 'dcid:USCitizenBornInTheUnitedStates',
+        }
+        dcid = statvar_dcid_generator.get_statvar_dcid(stat_var_dict2)
+        expected_dcid = 'Count_Person_USCitizenBornInTheUnitedStates'
         self.assertEqual(dcid, expected_dcid)
 
     def test_quantity_name_generation(self):
@@ -71,7 +82,7 @@ class TestStatVarDcidGenerator(unittest.TestCase):
             'gender': 'Female',
             'age': '[20 Years]'
         }
-        dcid = statvar_dcid_generator.get_stat_var_dcid(stat_var_dict1)
+        dcid = statvar_dcid_generator.get_statvar_dcid(stat_var_dict1)
         expected_dcid = 'Count_Person_20Years_Female'
         self.assertEqual(dcid, expected_dcid)
 
@@ -82,7 +93,7 @@ class TestStatVarDcidGenerator(unittest.TestCase):
             'gender': 'Female',
             'age': '[Years 20]'
         }
-        dcid = statvar_dcid_generator.get_stat_var_dcid(stat_var_dict2)
+        dcid = statvar_dcid_generator.get_statvar_dcid(stat_var_dict2)
         expected_dcid = 'Count_Person_20Years_Female'
         self.assertEqual(dcid, expected_dcid)
 
@@ -93,7 +104,7 @@ class TestStatVarDcidGenerator(unittest.TestCase):
             'populationType': 'HousingUnit',
             'numberOfRooms': '[9 - Rooms]',
         }
-        dcid = statvar_dcid_generator.get_stat_var_dcid(stat_var_dict1)
+        dcid = statvar_dcid_generator.get_statvar_dcid(stat_var_dict1)
         expected_dcid = 'Count_HousingUnit_9OrMoreRooms'
         self.assertEqual(dcid, expected_dcid)
 
@@ -103,7 +114,7 @@ class TestStatVarDcidGenerator(unittest.TestCase):
             'populationType': 'HousingUnit',
             'numberOfRooms': '[Rooms 9 -]',
         }
-        dcid = statvar_dcid_generator.get_stat_var_dcid(stat_var_dict2)
+        dcid = statvar_dcid_generator.get_statvar_dcid(stat_var_dict2)
         expected_dcid = 'Count_HousingUnit_9OrMoreRooms'
         self.assertEqual(dcid, expected_dcid)
 
@@ -113,7 +124,7 @@ class TestStatVarDcidGenerator(unittest.TestCase):
             'populationType': 'Household',
             'householdWorkerSize': '[- 3 Worker]',
         }
-        dcid = statvar_dcid_generator.get_stat_var_dcid(stat_var_dict3)
+        dcid = statvar_dcid_generator.get_statvar_dcid(stat_var_dict3)
         expected_dcid = 'Count_Household_3OrLessWorker'
         self.assertEqual(dcid, expected_dcid)
 
@@ -123,7 +134,7 @@ class TestStatVarDcidGenerator(unittest.TestCase):
             'populationType': 'Household',
             'householdWorkerSize': '[Worker - 3]',
         }
-        dcid = statvar_dcid_generator.get_stat_var_dcid(stat_var_dict4)
+        dcid = statvar_dcid_generator.get_statvar_dcid(stat_var_dict4)
         expected_dcid = 'Count_Household_3OrLessWorker'
         self.assertEqual(dcid, expected_dcid)
 
@@ -133,7 +144,7 @@ class TestStatVarDcidGenerator(unittest.TestCase):
             'populationType': 'Person',
             'income': '[10000 14999 USDollar]',
         }
-        dcid = statvar_dcid_generator.get_stat_var_dcid(stat_var_dict5)
+        dcid = statvar_dcid_generator.get_statvar_dcid(stat_var_dict5)
         expected_dcid = 'Count_Person_10000To14999USDollar'
         self.assertEqual(dcid, expected_dcid)
 
@@ -143,7 +154,7 @@ class TestStatVarDcidGenerator(unittest.TestCase):
             'populationType': 'Person',
             'income': '[USDollar 10000 14999]',
         }
-        dcid = statvar_dcid_generator.get_stat_var_dcid(stat_var_dict6)
+        dcid = statvar_dcid_generator.get_statvar_dcid(stat_var_dict6)
         expected_dcid = 'Count_Person_10000To14999USDollar'
         self.assertEqual(dcid, expected_dcid)
 
@@ -156,7 +167,7 @@ class TestStatVarDcidGenerator(unittest.TestCase):
             'educationalAttainment': 'BachelorsDegreeOrHigher',
             'race': 'AsianAlone',
         }
-        dcid = statvar_dcid_generator.get_stat_var_dcid(stat_var_dict)
+        dcid = statvar_dcid_generator.get_statvar_dcid(stat_var_dict)
         expected_dcid = ('Count_Person_25OrMoreYears_BachelorsDegreeOrHigher'
                          '_AsianAlone')
         self.assertEqual(dcid, expected_dcid)
@@ -170,7 +181,7 @@ class TestStatVarDcidGenerator(unittest.TestCase):
             'healthInsurance': 'dcid:NoHealthInsurance',
             'typeOf': 'dcs:StatisticalVariable'
         }
-        dcid = statvar_dcid_generator.get_stat_var_dcid(stat_var_dict1)
+        dcid = statvar_dcid_generator.get_statvar_dcid(stat_var_dict1)
         expected_dcid = ('MarginOfError_Count_Person_NoHealthInsurance_'
                          '1To1.49RatioToPovertyLine')
         self.assertEqual(dcid, expected_dcid)
@@ -181,7 +192,7 @@ class TestStatVarDcidGenerator(unittest.TestCase):
             'populationType': 'Atmosphere',
             'pollutant': 'PM2.5'
         }
-        dcid = statvar_dcid_generator.get_stat_var_dcid(stat_var_dict2)
+        dcid = statvar_dcid_generator.get_statvar_dcid(stat_var_dict2)
         expected_dcid = 'Mean_Concentration_Atmosphere_PM2.5'
         self.assertEqual(dcid, expected_dcid)
 
@@ -192,7 +203,7 @@ class TestStatVarDcidGenerator(unittest.TestCase):
             'populationType': 'Person',
             'placeOfResidenceClassification': 'Urban'
         }
-        dcid = statvar_dcid_generator.get_stat_var_dcid(stat_var_dict)
+        dcid = statvar_dcid_generator.get_statvar_dcid(stat_var_dict)
         expected_dcid = 'Mean_WagesDaily_Person_Urban'
         self.assertEqual(dcid, expected_dcid)
 
@@ -204,7 +215,7 @@ class TestStatVarDcidGenerator(unittest.TestCase):
             'memberOf': 'Climate',
             'measurementQualifier': 'Daily'
         }
-        dcid = statvar_dcid_generator.get_stat_var_dcid(stat_var_dict)
+        dcid = statvar_dcid_generator.get_statvar_dcid(stat_var_dict)
         expected_dcid = 'Daily_PrecipitationRate_Place'
         self.assertEqual(dcid, expected_dcid)
 
@@ -216,8 +227,8 @@ class TestStatVarDcidGenerator(unittest.TestCase):
             'consumedThing': 'Electricity',
             'measurementDenominator': 'PerCapita'
         }
-        dcid = statvar_dcid_generator.get_stat_var_dcid(stat_var_dict1)
-        expected_dcid = ('Amount_Consumption_Electricity_PerCapita')
+        dcid = statvar_dcid_generator.get_statvar_dcid(stat_var_dict1)
+        expected_dcid = 'Amount_Consumption_Electricity_PerCapita'
         self.assertEqual(dcid, expected_dcid)
 
         stat_var_dict2 = {
@@ -227,8 +238,8 @@ class TestStatVarDcidGenerator(unittest.TestCase):
             'memberOf': 'Demographics',
             'measurementDenominator': 'area'
         }
-        dcid = statvar_dcid_generator.get_stat_var_dcid(stat_var_dict2)
-        expected_dcid = ('Count_Person_PerArea')
+        dcid = statvar_dcid_generator.get_statvar_dcid(stat_var_dict2)
+        expected_dcid = 'Count_Person_PerArea'
         self.assertEqual(dcid, expected_dcid)
 
         stat_var_dict3 = {
@@ -239,7 +250,7 @@ class TestStatVarDcidGenerator(unittest.TestCase):
             'educationalAttainment': 'TertiaryEducation',
             'measurementDenominator': 'Count_Person_25To64Years'
         }
-        dcid = statvar_dcid_generator.get_stat_var_dcid(stat_var_dict3)
+        dcid = statvar_dcid_generator.get_statvar_dcid(stat_var_dict3)
         expected_dcid = ('Count_Person_25To64Years_TertiaryEducation'
                          '_AsAFractionOf_Count_Person_25To64Years')
         self.assertEqual(dcid, expected_dcid)


### PR DESCRIPTION
cc: @ajaits , @pradh, @beets 
Handled a minor edge case in constraint prefix removal.
Refactored constraint property handling into a separate function.
Changed names to be more consistent with the file name (stat_var -> statvar) and other style fixes.
