### PR TITLE
Adding a utility module to resolve geos from the us census codes

### DIFF
--- a/scripts/us_census/acs5yr/subject_tables/common/resolve_geo_id.py
+++ b/scripts/us_census/acs5yr/subject_tables/common/resolve_geo_id.py
@@ -1,0 +1,53 @@
+"""
+Resolving geoIds given the GEOID string from data,census.gov
+"""
+
+## The map between summary level and FIPS code is based on
+## https://www.census.gov/programs-surveys/geography/guidance/geo-identifiers.html
+## A detailed note of summary levels is available at https://mcdc.missouri.edu/geography/sumlevs/
+_SUMMARY_LEVELS_FIPS_CODE = {
+  '040': 2,
+  '050': 5,
+  '060': 10,
+  '140': 11,
+  '150': 12,
+  '160': 7,
+  '500': 4
+}
+
+def _convert_to_geoId(row):
+    """resolves GEOID based on the Census Summary level and the expected FIPS code
+    length for that summary level. If a geoId could not be resolved, fucntion returns.
+    an empty string ('').
+    """
+    ## Classification of geos is based on
+    ## https://www.census.gov/programs-surveys/geography/guidance/geo-identifiers.html
+    geographic_component, fips_code = row.split('US')
+
+    summary_level = geographic_component[:3]
+
+    ## Based on summary level and FIPS code, genereate geoId
+    if summary_level in _SUMMARY_LEVELS_FIPS_CODE:
+      if len(fips_code) == _SUMMARY_LEVELS_FIPS_CODE[summary_level]:
+        ### state/ county/ county_subdivision/ census_tract/ places/ congressional_district
+        return 'dcid:geoId/' + fips_code
+
+    elif summary_level == '010' and len(fips_code) == 1:
+      ### country
+      return 'dcid:country/USA'
+
+    #TODO[sharadshriram]: Support for zip code resolution is tested
+    # But will be supported in the subsequent PR
+    #elif summary_level =='860' and len(fips_code) == 5:
+    #  ### ZCTA
+    #  return 'dcid:zip/' + fips_code
+
+    #TODO[sharadshriram]: Support for school district resolution is tested
+    # But will be supported in the subsequent PR
+    #elif summary_level in ['950', '960', '970']:
+    #  ### School district
+    #  return 'dcid:geoId/sch' + fips_code
+
+    else:
+      ## if not an interesting summary level
+      return ''

--- a/scripts/us_census/acs5yr/subject_tables/common/resolve_geo_id.py
+++ b/scripts/us_census/acs5yr/subject_tables/common/resolve_geo_id.py
@@ -3,51 +3,46 @@ Resolving geoIds given the GEOID string from data,census.gov
 """
 
 ## The map between summary level and FIPS code is based on
-## https://www.census.gov/programs-surveys/geography/guidance/geo-identifiers.html
-## A detailed note of summary levels is available at https://mcdc.missouri.edu/geography/sumlevs/
+# https://www.census.gov/programs-surveys/geography/guidance/geo-identifiers.html
+# A detailed note is available at https://mcdc.missouri.edu/geography/sumlevs/
 _SUMMARY_LEVELS_FIPS_CODE = {
-  '040': 2,
-  '050': 5,
-  '060': 10,
-  '140': 11,
-  '150': 12,
-  '160': 7,
-  '500': 4
+    '040': 2,
+    '050': 5,
+    '060': 10,
+    '140': 11,
+    '150': 12,
+    '160': 7,
+    '500': 4
 }
+
 
 def _convert_to_geoId(row):
     """resolves GEOID based on the Census Summary level and the expected FIPS code
     length for that summary level. If a geoId could not be resolved, fucntion returns.
     an empty string ('').
     """
-    ## Classification of geos is based on
-    ## https://www.census.gov/programs-surveys/geography/guidance/geo-identifiers.html
+    # https://www.census.gov/programs-surveys/geography/guidance/geo-identifiers.html
     geographic_component, fips_code = row.split('US')
 
     summary_level = geographic_component[:3]
 
     ## Based on summary level and FIPS code, genereate geoId
     if summary_level in _SUMMARY_LEVELS_FIPS_CODE:
-      if len(fips_code) == _SUMMARY_LEVELS_FIPS_CODE[summary_level]:
-        ### state/ county/ county_subdivision/ census_tract/ places/ congressional_district
-        return 'dcid:geoId/' + fips_code
+        if len(fips_code) == _SUMMARY_LEVELS_FIPS_CODE[summary_level]:
+            return 'dcid:geoId/' + fips_code
 
     elif summary_level == '010' and len(fips_code) == 1:
-      ### country
-      return 'dcid:country/USA'
+        ### country
+        return 'dcid:country/USA'
 
-    #TODO[sharadshriram]: Support for zip code resolution is tested
-    # But will be supported in the subsequent PR
-    #elif summary_level =='860' and len(fips_code) == 5:
-    #  ### ZCTA
-    #  return 'dcid:zip/' + fips_code
+    elif summary_level == '860' and len(fips_code) == 5:
+        ### ZCTA
+        return 'dcid:zip/' + fips_code
 
-    #TODO[sharadshriram]: Support for school district resolution is tested
-    # But will be supported in the subsequent PR
-    #elif summary_level in ['950', '960', '970']:
-    #  ### School district
-    #  return 'dcid:geoId/sch' + fips_code
+    elif summary_level in ['950', '960', '970']:
+        ### School district
+        return 'dcid:geoId/sch' + fips_code
 
     else:
-      ## if not an interesting summary level
-      return ''
+        ## if not an interesting summary level
+        return ''

--- a/scripts/us_census/acs5yr/subject_tables/common/resolve_geo_id_test.py
+++ b/scripts/us_census/acs5yr/subject_tables/common/resolve_geo_id_test.py
@@ -1,0 +1,35 @@
+"""Tests for resolve_geo_id."""
+
+import unittest
+from resolve_geo_id import _convert_to_geoId
+
+class ResolveGeoIdTest(unittest.TestCase):
+  
+  def test_county_geoId(self):
+    # Sussex County, Delaware (0500000US10005)
+    self.assertEqual(_convert_to_geoId("0500000US10005"), 'dcid:geoId/10005')
+    # Natchitoches Parish, Louisiana (0500000US22069)
+    self.assertEqual(_convert_to_geoId("0500000US22069"), 'dcid:geoId/22069')
+
+  def test_state_geoId(self):
+    # California
+    self.assertEqual(_convert_to_geoId("0400000US06"), 'dcid:geoId/06')
+
+  def test_city_geoId(self):
+    # Arlington CDP, Virginia(1600000US5103000)
+    self.assertEqual(_convert_to_geoId("1600000US5103000"), 'dcid:geoId/5103000')
+
+  #def test_school_district_geoId(self):
+  #  # Portsmouth City Public Schools, Virginia (9700000US5103000)
+  #  self.assertEqual(_convert_to_geoId("9700000US5103000"), 'dcid:geoId/sch5103000')
+
+  def test_not_interesting_summary_levels(self):
+    # Dalton, GA Urbanized Area (2010)[400C100US22069]
+    self.assertEqual(_convert_to_geoId("400C100US22069"), '')
+
+  #def test_zip_code(self):
+  #  # 65203
+  #  self.assertEqual(_convert_to_geoId("86000US65203"), 'dcid:zip/65203')
+
+if __name__ == '__main__':
+  unittest.main()

--- a/scripts/us_census/acs5yr/subject_tables/common/resolve_geo_id_test.py
+++ b/scripts/us_census/acs5yr/subject_tables/common/resolve_geo_id_test.py
@@ -3,33 +3,39 @@
 import unittest
 from resolve_geo_id import _convert_to_geoId
 
+
 class ResolveGeoIdTest(unittest.TestCase):
-  
-  def test_county_geoId(self):
-    # Sussex County, Delaware (0500000US10005)
-    self.assertEqual(_convert_to_geoId("0500000US10005"), 'dcid:geoId/10005')
-    # Natchitoches Parish, Louisiana (0500000US22069)
-    self.assertEqual(_convert_to_geoId("0500000US22069"), 'dcid:geoId/22069')
 
-  def test_state_geoId(self):
-    # California
-    self.assertEqual(_convert_to_geoId("0400000US06"), 'dcid:geoId/06')
+    def test_county_geoId(self):
+        # Sussex County, Delaware (0500000US10005)
+        self.assertEqual(_convert_to_geoId("0500000US10005"),
+                         'dcid:geoId/10005')
+        # Natchitoches Parish, Louisiana (0500000US22069)
+        self.assertEqual(_convert_to_geoId("0500000US22069"),
+                         'dcid:geoId/22069')
 
-  def test_city_geoId(self):
-    # Arlington CDP, Virginia(1600000US5103000)
-    self.assertEqual(_convert_to_geoId("1600000US5103000"), 'dcid:geoId/5103000')
+    def test_state_geoId(self):
+        # California
+        self.assertEqual(_convert_to_geoId("0400000US06"), 'dcid:geoId/06')
 
-  #def test_school_district_geoId(self):
-  #  # Portsmouth City Public Schools, Virginia (9700000US5103000)
-  #  self.assertEqual(_convert_to_geoId("9700000US5103000"), 'dcid:geoId/sch5103000')
+    def test_city_geoId(self):
+        # Arlington CDP, Virginia(1600000US5103000)
+        self.assertEqual(_convert_to_geoId("1600000US5103000"),
+                         'dcid:geoId/5103000')
 
-  def test_not_interesting_summary_levels(self):
-    # Dalton, GA Urbanized Area (2010)[400C100US22069]
-    self.assertEqual(_convert_to_geoId("400C100US22069"), '')
+    def test_school_district_geoId(self):
+        # Portsmouth City Public Schools, Virginia (9700000US5103000)
+        self.assertEqual(_convert_to_geoId("9700000US5103000"),
+                         'dcid:geoId/sch5103000')
 
-  #def test_zip_code(self):
-  #  # 65203
-  #  self.assertEqual(_convert_to_geoId("86000US65203"), 'dcid:zip/65203')
+    def test_not_interesting_summary_levels(self):
+        # Dalton, GA Urbanized Area (2010)[400C100US22069]
+        self.assertEqual(_convert_to_geoId("400C100US22069"), '')
+
+    def test_zip_code(self):
+        # 65203
+        self.assertEqual(_convert_to_geoId("86000US65203"), 'dcid:zip/65203')
+
 
 if __name__ == '__main__':
-  unittest.main()
+    unittest.main()


### PR DESCRIPTION
The proposed module aids in the resolution of geos based on the summary levels at which they appear in the subject tables. The geoId is resolved based on the summary level which is typically the [first 3 digits of the code](https://www.census.gov/programs-surveys/geography/technical-documentation/naming-convention/cartographic-boundary-file/carto-boundary-summary-level.html) and [GEOID Structure](https://www.census.gov/programs-surveys/geography/guidance/geo-identifiers.html) for Geographic Areas which describes the number of digits required to specify a location at a summary level.

|Summary Level|Place Name| Census Code| Resolved geoId| 
|------------|------------|--------------|----------------| 
|County|Sussex County, Delaware |0500000US10005| ['dcid:geoId/10005'](https://datacommons.org/browser/geoId/10005)|
|County|Natchitoches Parish, Louisiana |0500000US22069| ['dcid:geoId/22069'](https://datacommons.org/browser/geoId/22069)|
|State|California|0400000US06|['dcid:geoId/06'](https://datacommons.org/browser/geoId/06)|
|City|Arlington CDP, Virginia|1600000US5103000|['dcid:geoId/5103000'](https://datacommons.org/browser/geoId/5103000)|
|School District|Portsmouth City Public Schools, Virginia|9700000US5103000|[dcid:geoId/sch5103000](https://datacommons.org/browser/geoId/sch5103000)|
|Zip Codes (censusZCTA)|65203|86000US65203|['dcid:zip/65203'](https://datacommons.org/browser/zip/65203)|