### PR TITLE
Drop outermost NUTS regions from DP* values

### DIFF
--- a/scripts/eurostat/geodata/generate_mcf.py
+++ b/scripts/eurostat/geodata/generate_mcf.py
@@ -85,7 +85,7 @@ def _generate_file(in_dir, out_dir, res, lvl, gj_prop):
                 gj = json.dumps(json.dumps(f['geometry']))
                 nuts_id = f['properties']['NUTS_ID']
                 if (gj_prop != 'geoJsonCoordinates' and
-                    _is_outermost_geo(nuts_id)):
+                        _is_outermost_geo(nuts_id)):
                     continue
                 fout.write(
                     _MCF_FORMAT.format(nuts_dcid='nuts/' + nuts_id,


### PR DESCRIPTION
As described [here](https://en.wikipedia.org/wiki/Special_member_state_territories_and_the_European_Union#Outermost_regions), there are just a handful of NUTS regions that are situated at a significant distance from Europe.

For now, drop geo-jsons for those in the DP* version of the attributes, which tend to be used for display purposes.