### PR TITLE
ACS5yrSubjectTables : Added map in geoId resolver to handle wrong geoIds

### DIFF
--- a/scripts/us_census/acs5yr/subject_tables/common/resolve_geo_id.py
+++ b/scripts/us_census/acs5yr/subject_tables/common/resolve_geo_id.py
@@ -66,7 +66,7 @@ _US_SUMMARY_LEVEL_GEO_PREFIX_MAP = {
     '010': 'country/USA'
 }
 
-_US_REPLACE_GEO_CODE_MAP = {
+_US_GEO_CODE_UPDATE_MAP = {
     # Replacing/Updating GeoID given in the data. Required in case of wrong geoid mentioned in the data.
     # Reference : https://www.census.gov/programs-surveys/acs/technical-documentation/table-and-geography-changes/2017/geography-changes.html
     # Invalid fips code for Tucker City 1377625 replaced by 1377652
@@ -85,8 +85,8 @@ def convert_to_place_dcid(geoid_str):
     ## Based on summary level, generate place dcid
     if summary_level in _US_SUMMARY_LEVEL_GEO_PREFIX_MAP:
         ## Update fips code
-        if fips_code in _US_REPLACE_GEO_CODE_MAP:
-            fips_code = _US_REPLACE_GEO_CODE_MAP[fips_code]
+        if fips_code in _US_GEO_CODE_UPDATE_MAP:
+            fips_code = _US_GEO_CODE_UPDATE_MAP[fips_code]
         return _US_SUMMARY_LEVEL_GEO_PREFIX_MAP[summary_level] + fips_code
     else:
         ## if not an interesting summary level

--- a/scripts/us_census/acs5yr/subject_tables/common/resolve_geo_id.py
+++ b/scripts/us_census/acs5yr/subject_tables/common/resolve_geo_id.py
@@ -66,6 +66,13 @@ _US_SUMMARY_LEVEL_GEO_PREFIX_MAP = {
     '010': 'country/USA'
 }
 
+_US_REPLACE_GEO_CODE_MAP = {
+    # Replacing/Updating GeoID given in the data. Required in case of wrong geoid mentioned in the data.
+    # Reference : https://www.census.gov/programs-surveys/acs/technical-documentation/table-and-geography-changes/2017/geography-changes.html
+    # Invalid fips code for Tucker City 1377625 replaced by 1377652
+    '1377625': '1377652'
+}
+
 
 def convert_to_place_dcid(geoid_str):
     """resolves GEOID based on the Census Summary level. If a geoId could not be
@@ -77,6 +84,9 @@ def convert_to_place_dcid(geoid_str):
 
     ## Based on summary level, generate place dcid
     if summary_level in _US_SUMMARY_LEVEL_GEO_PREFIX_MAP:
+        ## Update fips code
+        if fips_code in _US_REPLACE_GEO_CODE_MAP:
+            fips_code = _US_REPLACE_GEO_CODE_MAP[fips_code]
         return _US_SUMMARY_LEVEL_GEO_PREFIX_MAP[summary_level] + fips_code
     else:
         ## if not an interesting summary level

--- a/scripts/us_census/acs5yr/subject_tables/common/resolve_geo_id_test.py
+++ b/scripts/us_census/acs5yr/subject_tables/common/resolve_geo_id_test.py
@@ -14,7 +14,7 @@
 """Tests for resolve_geo_id."""
 
 import unittest
-from resolve_geo_id import convert_to_place_dcid
+from .resolve_geo_id import convert_to_place_dcid
 
 _TEST_GEOIDS = {
     '0100000US': 'country/USA',  # Country (US)
@@ -23,27 +23,29 @@ _TEST_GEOIDS = {
     '0500000US10005': 'geoId/10005',  # Sussex County, Delaware (0500000US10005)
     '0500000US22069':
         'geoId/22069',  # Natchitoches Parish, Louisiana (0500000US22069)
-    # '1400000US06007000104': '',  # Census Tract 1.04, Butte County, California
-    # '1500000USC17020': '',  # Chico, CA Metro Area
+    '1400000US06007000104': '',  # Census Tract 1.04, Butte County, California
+    '1500000USC17020': '',  # Chico, CA Metro Area
     '1600000US5103000':
         'geoId/5103000',  # Arlington CDP, Virginia(1600000US5103000)
-    # '5000000US0601':
-    #     '',  # Congressional District 1 (113th Congress), California
-    # '86000US65203': '',  # Zip Code (ZCTA)
-    # '9500000US0602250': '',  # Alta-Dutch Flat Union Elementary School District
-    # '9600000US0605940': '',  # Bret Harte Union High School District
-    # '9700000US5103000':
-    #     '',  # Portsmouth City Public Schools, Virginia (9700000US5103000)
-    # '400C100US22069': '',  # Dalton, GA Urbanized Area (2010)[400C100US22069] 
-    '1600000US1377652': 'geoId/1377652', # Tucker city, Georgia 
+    '5000000US0601':
+        '',  # Congressional District 1 (113th Congress), California
+    '86000US65203': '',  # Zip Code (ZCTA)
+    '9500000US0602250': '',  # Alta-Dutch Flat Union Elementary School District
+    '9600000US0605940': '',  # Bret Harte Union High School District
+    '9700000US5103000':
+        '',  # Portsmouth City Public Schools, Virginia (9700000US5103000)
+    '400C100US22069': '',  # Dalton, GA Urbanized Area (2010)[400C100US22069] 
+    '1600000US1377652': 'geoId/1377652',  # Tucker city, Georgia 
     '1600000US1377625': 'geoId/1377652'  # Tucker city, Georgia
 }
+
 
 class ResolveCensusGeoIdTest(unittest.TestCase):
 
     def test_geoIds_at_all_summary_levels(self):
         for geo_str, expected_geoId in _TEST_GEOIDS.items():
             self.assertEqual(convert_to_place_dcid(geo_str), expected_geoId)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/scripts/us_census/acs5yr/subject_tables/common/resolve_geo_id_test.py
+++ b/scripts/us_census/acs5yr/subject_tables/common/resolve_geo_id_test.py
@@ -14,7 +14,7 @@
 """Tests for resolve_geo_id."""
 
 import unittest
-from .resolve_geo_id import convert_to_place_dcid
+from resolve_geo_id import convert_to_place_dcid
 
 _TEST_GEOIDS = {
     '0100000US': 'country/USA',  # Country (US)
@@ -23,27 +23,27 @@ _TEST_GEOIDS = {
     '0500000US10005': 'geoId/10005',  # Sussex County, Delaware (0500000US10005)
     '0500000US22069':
         'geoId/22069',  # Natchitoches Parish, Louisiana (0500000US22069)
-    '1400000US06007000104': '',  # Census Tract 1.04, Butte County, California
-    '1500000USC17020': '',  # Chico, CA Metro Area
+    # '1400000US06007000104': '',  # Census Tract 1.04, Butte County, California
+    # '1500000USC17020': '',  # Chico, CA Metro Area
     '1600000US5103000':
         'geoId/5103000',  # Arlington CDP, Virginia(1600000US5103000)
-    '5000000US0601':
-        '',  # Congressional District 1 (113th Congress), California
-    '86000US65203': '',  # Zip Code (ZCTA)
-    '9500000US0602250': '',  # Alta-Dutch Flat Union Elementary School District
-    '9600000US0605940': '',  # Bret Harte Union High School District
-    '9700000US5103000':
-        '',  # Portsmouth City Public Schools, Virginia (9700000US5103000)
-    '400C100US22069': ''  # Dalton, GA Urbanized Area (2010)[400C100US22069]
+    # '5000000US0601':
+    #     '',  # Congressional District 1 (113th Congress), California
+    # '86000US65203': '',  # Zip Code (ZCTA)
+    # '9500000US0602250': '',  # Alta-Dutch Flat Union Elementary School District
+    # '9600000US0605940': '',  # Bret Harte Union High School District
+    # '9700000US5103000':
+    #     '',  # Portsmouth City Public Schools, Virginia (9700000US5103000)
+    # '400C100US22069': '',  # Dalton, GA Urbanized Area (2010)[400C100US22069] 
+    '1600000US1377652': 'geoId/1377652', # Tucker city, Georgia 
+    '1600000US1377625': 'geoId/1377652'  # Tucker city, Georgia
 }
-
 
 class ResolveCensusGeoIdTest(unittest.TestCase):
 
     def test_geoIds_at_all_summary_levels(self):
         for geo_str, expected_geoId in _TEST_GEOIDS.items():
             self.assertEqual(convert_to_place_dcid(geo_str), expected_geoId)
-
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR adds map in geoId resolver script to replace wrong geoIds. Currently, it only handles geoId for Tucker city, Georgia.

Wrong geoId found for Tucker City, Georgia in 2016 data:
- Actual geoId for Tucker city - geoId/1377652 
- GeoId corresponding to year 2016 : geoId/1377625 (Does not exist)
