### PR TITLE
updating the property name based on schema changes

### DIFF
--- a/util/statvar_dcid_generator.py
+++ b/util/statvar_dcid_generator.py
@@ -218,8 +218,8 @@ _PREPEND_APPEND_REPLACE_MAP = {
     'placeOfBirth': {
         'prepend': 'PlaceOfBirth'
     },
-    'dateMovedIntoHousingUnit': {
-        'prepend': 'MovedIn',
+    'dateMovedIn': {
+        'prepend': 'MovedInDate',
         'replace': 'Date',
         'replacement': ''
     },


### PR DESCRIPTION
`dateMovedIntoHousingUnit` is renamed as `dateMovedIn` in the `statvar_dcid_generator.py` tool