### PR TITLE
Add yapfignore to ignore large and unnecessary files

### DIFF
--- a/.yapfignore
+++ b/.yapfignore
@@ -1,0 +1,15 @@
+util/aa_isocode2dcid.py
+util/county_to_dcid.py
+util/soc_codes.py
+
+scripts/*/*/scratch
+scripts/*/*/*/scratch
+scripts/*/*/*/*/scratch
+scripts/*/*/*/*/*/scratch
+
+.env/
+*/.env/
+*/*/.env/
+*/*/*/.env/
+*/*/*/*/.env/
+*/*/*/*/*/.env/


### PR DESCRIPTION
Now 20s:

```
shanth:~/work/git/data (engprod1 %)$ time yapf -r -i -p --style=google util/ scripts/ import-automation/

real    0m20.748s
user    1m41.213s
sys     0m7.358s
```

Used to be 4m:

![Screen Shot 2022-11-11 at 9 20 12 AM](https://user-images.githubusercontent.com/4375037/201395028-e3cc3f04-780c-4e7b-8c18-72b57ff27742.png)

https://github.com/datacommonsorg/data/pull/761 increased it to 16m:

![Screen Shot 2022-11-11 at 9 23 01 AM](https://user-images.githubusercontent.com/4375037/201395172-ecbb63f6-ea0d-4fdd-95b1-881df118327f.png)
