### PR TITLE
Add USDA mealsites

### DIFF
--- a/scripts/techsoup/us_usda/Summer_Meal_Sites_2022_v0.tmcf
+++ b/scripts/techsoup/us_usda/Summer_Meal_Sites_2022_v0.tmcf
@@ -1,0 +1,22 @@
+Node: E:Data->E1
+typeOf: UsdaSummerMealSite
+day: E:Data->E2
+longitude: C:Data->X
+latitude: C:Data->Y
+city: C:Data->siteCity
+state: C:Data->siteState
+zip: C:Data->siteZip
+county: C:Data->County
+season: C:Data->Season
+
+Node: E:Data->E2
+dcid: <summer-meal-site-dcid>-<day>
+typeOf: UsdaSummerMealSiteDay
+day: C:daysofOperation
+breakfastHours: C:Data->breakfastTime
+lunchHours: C:Data->lunchTime
+morningSnackHours: C:Data->snackTimeAM
+afternoonSnackHours: C:Data->snackTimePM
+dinnerHours: C:Data->dinnerSupperTime
+startDate: C:Data->startDate
+endDate: C:Data->endDate


### PR DESCRIPTION
Includes a csv of the mealsite data, and the tmcf.

An additional node was created for the operating day, with related operational info added to that node.

Reference doc [here](https://docs.google.com/document/d/1POEUzCzKkjYpUVCDRz9Jbn4cqt9PNrWa1VdgWusKDKU/edit?usp=sharing).