### PR TITLE
config and script for auto-refresh of fires

### DIFF
--- a/scripts/fires/firms/fire_events_pipeline_config.py
+++ b/scripts/fires/firms/fire_events_pipeline_config.py
@@ -1,0 +1,190 @@
+# Config to generate FireEvent through the script: events_pipeline.py
+{
+    'defaults': {
+        'import_name': 'FIRMSFires',
+        # Set start_date to start of year to be processed.
+        # Defaults to Jan 1 of current year if left empty.
+        'start_date': '',
+        # Aggregate events upto the end of the year from per-day source files.
+        'end_date': '{year}-12-31',
+        'batch_days': 1,
+        'time_period': 'P{batch_days}D',
+
+        # GCS settings
+        'gcs_project': 'datcom',
+        'gcs_bucket': 'datcom-prod-imports',
+        'gcs_folder': 'scripts/fires/firms',
+    },
+    # State of previous run of the pipeline with input/output for each stage.
+    'pipeline_state_file':
+        'gs://datcom-prod-imports/scripts/fires/firms/flood_event_pipeline_state_{year}.py',
+
+    # Pipeline stages to generate flood events.
+    'stages': [
+        # Download NASA FIRMS fires data using the API
+        {
+            'stage':
+                'download',
+
+            # API key for NASA FIRMS data download
+            # Get a MAPS_KEY from https://firms.modaps.eosdis.nasa.gov/api/area/
+            #'nasa_firms_api_key':
+            #    '<REPLACE_WITH_YOUR_KEY>',
+            'nasa_firms_api_key':
+                '712d4ebd9b976c57efddedad99e72cd3',
+            #'nasa_data_source': "VIIRS_SNPP_NRT",  # upto last 60 days
+            'nasa_data_source':
+                "VIIRS_SNPP_SP",  # older than 60 days
+            'batch_days':
+                1,
+            'url':
+                "https://firms.modaps.eosdis.nasa.gov/api/area/csv/{nasa_firms_api_key}/{nasa_data_source}/world/{batch_days}/{start_date}",
+            # API rate limits downloads.
+            # retry downloads after 200 secs until a CSV with date is downloaded.
+            'successful_response_regex':
+                '{year}',
+            'retry_interval':
+                200,
+            'retry_count':
+                10,
+            'output_file':
+                'gs://{gcs_bucket}/{gcs_folder}/download/{year}/{import_name}-download-{start_date}-{time_period}.csv',
+            'skip_existing_output':
+                True,
+        },
+
+        # Add S2 cells to the downloaded CSV files.
+        {
+            'stage':
+                'raster_csv',
+            'time_period':
+                'P{batch_days}D',
+            's2_level':
+                10,
+            'aggregate':
+                None,
+            'input_data_filter': {
+                'area': {
+                    # pick max area for s2 cell.
+                    # each fire in input is a fixed region.
+                    'aggregate': 'max'
+                },
+            },
+            'input_files':
+                'gs://{gcs_bucket}/{gcs_folder}/download/{year}/{import_name}-download-{year}*.csv',
+            'output_dir':
+                'gs://{gcs_bucket}/{gcs_folder}/{stage}/{year}',
+            'skip_existing_output':
+                True,
+        },
+
+        # Generate events from the CSV with flooded S2 cells per month.
+        {
+            'stage':
+                'events',
+
+            # Process all data files for the whole year.
+            'input_files':
+                'gs://{gcs_bucket}/{gcs_folder}/raster_csv/{year}/*{year}*.csv',
+            # Output events csv into a common folder with a year in filename,
+            # as the import automation can copy all files in a single folder.
+            'output_dir':
+                'gs://{gcs_bucket}/{gcs_folder}/{stage}/{import_name}-{stage}-{year}-',
+            'event_type':
+                'FireEvent',
+
+            # Input settings.
+            # Columns of input_csv that are added as event properties
+            'data_columns': [
+                'area', 'frp', 'bright_ti4', 'bright_ti5', 'confidence'
+            ],
+            # Columns of input_csv that contains the s2 cell id.
+            'place_column':
+                's2CellId',
+            # Input column for date.
+            'date_column':
+                'acq_date',
+
+            # Processing settings
+            # Maximum distance within which 2 events are merged.
+            'max_overlap_distance_km':
+                0,
+            # Maximum number of cells of same level in between 2 events to be merged.
+            'max_overlap_place_hop':
+                1,
+            # S2 level to which data is aggregated.
+            's2_level':
+                10,  # Events are at resolution of level-10 S2 cells.
+            'aggregate':
+                'sum',  # default aggregation for all properties
+            # Per property settings
+            'property_config': {
+                'area': {
+                    'aggregate': 'sum',
+                    'unit': 'SquareKilometer',
+                },
+                'affectedPlace': {
+                    'aggregate': 'list',
+                },
+            },
+            # Per property filter params for input data.
+            'input_filter_config': {
+                'confidence': {
+                    'regex': '[nh]',
+                }
+            },
+            'output_events_filter_config': {
+                'AreaSqKm': {
+                    # Only allow fire events with atleast 4sqkm (10%) of events.
+                    'min': 4.0,
+                },
+            },
+            # Per property settings
+            'property_config': {
+                'aggregate': 'max',
+                'area': {
+                    'aggregate': 'sum',
+                    'unit': 'SquareKilometer',
+                },
+            },
+            # Treat events at the same location beyond 3 days as separate events.
+            'max_event_interval_days':
+                3,
+            # Limit time range for an event to 3 months, roughly a season
+            'max_event_duration_days':
+                90,
+            # Limit event affected region to 1000 L10 s2 cells, roughly 100K sqkm.
+            'max_event_places':
+                1000,
+
+            # Enable DC API lookup for place properties
+            'dc_api_enabled':
+                False,
+            'dc_api_batch_size':
+                200,
+            # Cache file for place properties like name, location, typeOf
+            # Cache is updated with new places looked up.
+            'place_property_cache_file':
+                'gs://datcom-prod-imports/place_cache/place_properties_cache_with_s2_10.pkl',
+
+            # Output settings.
+            'output_svobs':
+                True,
+            'output_delimiter':
+                ',',
+            'output_affected_place_polygon':
+                'geoJsonCoordinates',
+            'polygon_simplification_factor':
+                None,
+            'output_geojson_string':
+                True,
+
+            # Output svobs per place
+            # Place svobs generated by entity aggregation pipeline
+            'output_place_svobs':
+                False,
+            'output_place_svobs_properties': ['area', 'count'],
+            'output_place_svobs_dates': ['YYYY-MM-DD', 'YYYY-MM', 'YYYY'],
+        },
+    ],
+}

--- a/scripts/fires/firms/generate_fire_events.py
+++ b/scripts/fires/firms/generate_fire_events.py
@@ -1,0 +1,87 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Script to generate Fire events using the events pipeline.
+
+The events pipeline is setup with the following stages:
+  1. download
+     Download the NASA FIRMS fires data wiht lat/long of each fire location
+     as a CSV.
+
+  2. raster_csv
+     The downloaded CSV with lat/long of fires is processed to add
+     an S2 cell of level 13 for each row using the raster_to_csv.py utilities.
+
+  3. events
+     The resulting CSV with s2 cells with fires is aggregated into events using
+     the process_events.py. Neighbouring s2 cells with fires are collated into
+     a single event. s2 cells with water in successive time periods are also
+     added into the same event.
+
+     Once the regions with fires are collated into events, the process_events.py
+     utilities also generate a CSV with StatVar Observations for Area_FireEvent and
+     Count_FireEvent for each events s2 cells at level 10, and places it is
+     contained in, such as AdministrativeArea, Country, Continent and Earth.
+
+  The generated files including the downloaded CSV, CSV with S2 cells and events
+  are saved in GCS.
+
+  The script runs once a week to update fire events for the current year.
+"""
+
+import os
+import re
+import sys
+import time
+
+from absl import app
+from absl import flags
+from absl import logging
+
+_SCRIPTS_DIR = os.path.dirname(__file__)
+sys.path.append(_SCRIPTS_DIR)
+sys.path.append(os.path.dirname(_SCRIPTS_DIR))
+sys.path.append(os.path.dirname(os.path.dirname(_SCRIPTS_DIR)))
+sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(_SCRIPTS_DIR))))
+sys.path.append(os.path.join(os.path.dirname(os.path.dirname(_SCRIPTS_DIR)), 'earthengine'))
+sys.path.append(
+    os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(_SCRIPTS_DIR))), 'util'))
+
+import file_util
+
+from config_map import ConfigMap
+from events_pipeline import EventPipeline
+
+flags.DEFINE_string(
+    'fire_pipeline_config',
+    os.path.join(_SCRIPTS_DIR, 'fire_events_pipeline_config.py'),
+    'Config for the pipeline as a py dictionary of json')
+
+flags.DEFINE_list(
+    'fire_pipeline_stages', [],
+    'List of stages in the fire events pipeline config to be run.')
+
+_FLAGS = flags.FLAGS
+
+
+def main(_):
+    config=ConfigMap(
+        filename=_FLAGS.fire_pipeline_config)
+    if _FLAGS.start_date:
+      config.get('defaults', {})['start_date'] = _FLAGS.start_date
+    pipeline = EventPipeline(config=config)
+    pipeline.run(run_stages=_FLAGS.fire_pipeline_stages)
+
+
+if __name__ == '__main__':
+    app.run(main)


### PR DESCRIPTION
COnfig for fires events pipeline that does the following:
- downloads the latest fires csv with lat/lng form NASA
- converts the csv to S2 cells.
- generates events for the current year

The import automation setup copies over all the events CSVs into DC.