### PR TITLE
Import automation: Setup script updates

### DIFF
--- a/import-automation/executor/Dockerfile
+++ b/import-automation/executor/Dockerfile
@@ -16,7 +16,10 @@
 
 FROM python:3.11.4
 
-RUN apt upgrade
+RUN apt-get update \
+    && apt-get -y upgrade \
+    && apt-get -y autoremove \
+    && rm -rf /var/lib/apt/lists/*
 WORKDIR /workspace
 
 ADD requirements.txt /workspace/requirements.txt

--- a/import-automation/executor/app/executor/cloud_scheduler.py
+++ b/import-automation/executor/app/executor/cloud_scheduler.py
@@ -26,7 +26,7 @@ from google.cloud import scheduler_v1
 from google.protobuf import json_format
 from google.api_core.exceptions import AlreadyExists, NotFound
 
-GKE_SERVICE_DOMAIN = os.getenv('GKE_SERVICE_DOMAIN', 'import.datacommons.dev')
+GKE_SERVICE_DOMAIN = os.getenv('GKE_SERVICE_DOMAIN', 'importautomation.datacommons.org')
 GKE_CALLER_SERVICE_ACCOUNT = os.getenv('CLOUD_SCHEDULER_CALLER_SA')
 GKE_OAUTH_AUDIENCE = os.getenv('CLOUD_SCHEDULER_CALLER_OAUTH_AUDIENCE')
 

--- a/import-automation/executor/gke/README.md
+++ b/import-automation/executor/gke/README.md
@@ -26,8 +26,11 @@ Follow
 
 ## (One Time) Setup GKE
 
-1. Update OAUTH_CLIENT_ID and OAUTH_CLIENT_SECRET in "gke/configure_gke.sh".
-2. Run `./gke/configure_gke.sh`.
+1. Update the PROJECT_ID in "gke/configure_gke.sh", if needed.
+
+2. Update OAUTH_CLIENT_ID and OAUTH_CLIENT_SECRET in "gke/configure_gke.sh".
+
+3. Run `./gke/configure_gke.sh`.
 
 ## Deployment
 

--- a/import-automation/executor/gke/configure_gke.sh
+++ b/import-automation/executor/gke/configure_gke.sh
@@ -14,7 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-PROJECT_ID=datcom-data
+# Edit the PROJECT_ID below.
+PROJECT_ID=datcom-import-automation
 
 gcloud config set project $PROJECT_ID
 
@@ -40,11 +41,9 @@ kubectl create namespace import-automation \
 kubectl create serviceaccount --namespace import-automation import-automation-ksa \
   --dry-run=client -o yaml | kubectl apply -f -
 
-gcloud iam service-accounts add-iam-policy-binding \
-  --project $PROJECT_ID \
-  --role roles/iam.workloadIdentityUser \
-  --member "serviceAccount:$PROJECT_ID.svc.id.goog[import-automation/import-automation-ksa]" \
-  $PROJECT_ID@appspot.gserviceaccount.com
+gcloud projects add-iam-policy-binding $PROJECT_ID \
+  --role=roles/iam.workloadIdentityUser \
+  --member="serviceAccount:$PROJECT_ID.svc.id.goog[import-automation/import-automation-ksa]"
 
 kubectl annotate serviceaccount \
   --namespace import-automation \
@@ -53,8 +52,8 @@ kubectl annotate serviceaccount \
   iam.gke.io/gcp-service-account=$PROJECT_ID@appspot.gserviceaccount.com
 
 # Set the oauth env vars before running the script
-# export OAUTH_CLIENT_ID=<fill>
-# export OAUTH_CLIENT_SECRET=<fill>
+# export OAUTH_CLIENT_ID=251280076183-ivh5hjgshftv3rgo4mc03t3vbkgdj3at.apps.googleusercontent.com
+# export OAUTH_CLIENT_SECRET=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
 kubectl -n import-automation create secret generic import-automation-iap-secret \
   --from-literal=client_id=$OAUTH_CLIENT_ID \
   --from-literal=client_secret=$OAUTH_CLIENT_SECRET

--- a/import-automation/executor/requirements.txt
+++ b/import-automation/executor/requirements.txt
@@ -9,3 +9,4 @@ flask
 gunicorn
 pytz
 absl-py
+libwebp-dev>=1.3.2  # To fix a zero-day vulnerability (CVE-2023-4863): https://snyk.io/blog/find-and-fix-webp-vulnerability-cve-2023-4863/

--- a/import-automation/executor/test/cloud_scheduler_test.py
+++ b/import-automation/executor/test/cloud_scheduler_test.py
@@ -84,7 +84,7 @@ class CloudSchedulerTest(unittest.TestCase):
                 'seconds': 60 * 30
             },
             'http_target': {
-                'uri': 'https://import.datacommons.dev/update',
+                'uri': 'https://importautomation.datacommons.org/update',
                 'http_method': 'POST',
                 'headers': {
                     'Content-Type': 'application/json',


### PR DESCRIPTION
In this PR, we have the following changes:

1. Updates to the Dockerfile and requirements.txt to fix a zero-day vulnerability (see: https://snyk.io/blog/find-and-fix-webp-vulnerability-cve-2023-4863/)
2. Some minor updates to the GKE setup scripts to ensure the cluster/workloads are deployed on a new project.
3. Updating the url endpoint (domain) of the global load balancer to: importautomation.datacommons.org which has been mapped to the load balancer's static ip address in Google Domains.