### PR TITLE
Import Automation: package installation fix

### DIFF
--- a/import-automation/executor/requirements.txt
+++ b/import-automation/executor/requirements.txt
@@ -9,4 +9,3 @@ flask
 gunicorn
 pytz
 absl-py
-libwebp-dev>=1.3.2  # To fix a zero-day vulnerability (CVE-2023-4863): https://snyk.io/blog/find-and-fix-webp-vulnerability-cve-2023-4863/


### PR DESCRIPTION
This package is not a python package and should be upgraded when apt-get upgrade is used.