### PR TITLE
USDA Import: Multiprocessing bug fix

### DIFF
--- a/scripts/us_usda/quickstats/process.py
+++ b/scripts/us_usda/quickstats/process.py
@@ -325,6 +325,7 @@ def load_usda_api_key():
 
 
 def get_usda_api_key():
+    _FLAGS(sys.argv)
     return _FLAGS.usda_api_key
 
 


### PR DESCRIPTION
Fixing a multiprocessing FLAG parsing error on some platforms/environments.

The import was failing on Mac OS-X and also on a Cloud Scheduler workflow. Appears to be a known issue on certain environments and it's better to fix using this one-line change. See https://stackoverflow.com/questions/66953343/absl-flags-error-trying-to-access-flag-before-flags-were-parsed for more details.