### PR TITLE
[Import Automation] Script to invoke updates for imports locally

### DIFF
--- a/import-automation/executor/README.md
+++ b/import-automation/executor/README.md
@@ -47,12 +47,34 @@ Commons knowledge graph using the importer.
 
 ## Running locally
 
+## Updating An Import Locally
+
+Authenticate with GCP first: `gcloud auth application-default login`
+
+You can execute an import job from your local end by invoking the following script:
+
+```
+Run `./schedule_update_import.sh -u <config_project_id> <path_to_import> <import_script_args>`
+```
+
+Run `./schedule_update_import.sh --help` for usage.
+
+`<config_project_id>` is the GCP project id where the config file is stored, e.g. `datcom-import-automation`.
+`<path_to_import>` is the path to the import (relative to the root directory of the `data` repo), with the name of the import provided with a colon, e.g. `scripts/us_usda/quickstats:UsdaAgSurvey`.
+`import_script_args` is one string (enclosed by quotes) representing all the command line args to be provided to the import script, e.g. `"--start_year=2023 --another_flag=val"`.
+
+Example invokation:
+
+```
+Run `./schedule_update_import.sh -u datcom-import-automation scripts/us_usda/quickstats:UsdaAgSurvey "--start_year=2023"`
+```
+
+## Local Executor [should be deprecated soon]
+
 ```
 PYTHONPATH=$(pwd) python app/main.py
 
 ``
-
-## Local Executor
 
 Run `. run_local_executor.sh --help` for usage.
 

--- a/import-automation/executor/README.md
+++ b/import-automation/executor/README.md
@@ -58,19 +58,18 @@ Once the script runs to completion, the data directory's latest update is printe
 Ensure this script is executed from the directory which contains `schedule_update_import.sh`, i.e. from `/data/import-automation/executor`.
 
 ```
-Run `./schedule_update_import.sh -u <config_project_id> <path_to_import> <import_script_args>`
+Run `./schedule_update_import.sh -u <config_project_id> <path_to_import>`
 ```
 
 Run `./schedule_update_import.sh --help` for usage.
 
 `<config_project_id>` is the GCP project id where the config file is stored, e.g. `datcom-import-automation`.
 `<path_to_import>` is the path to the import (relative to the root directory of the `data` repo), with the name of the import provided with a colon, e.g. `scripts/us_usda/quickstats:UsdaAgSurvey`.
-`import_script_args` is one string (enclosed by quotes) representing all the command line args to be provided to the import script, e.g. `"--start_year=2023 --another_flag=val"`.
 
 Example invocation:
 
 ```
-Run `./schedule_update_import.sh -u datcom-import-automation scripts/us_usda/quickstats:UsdaAgSurvey "--start_year=2023"`
+Run `./schedule_update_import.sh -u datcom-import-automation scripts/us_usda/quickstats:UsdaAgSurvey`
 ```
 
 ## Local Executor [should be deprecated soon]

--- a/import-automation/executor/README.md
+++ b/import-automation/executor/README.md
@@ -51,7 +51,11 @@ Commons knowledge graph using the importer.
 
 Authenticate with GCP first: `gcloud auth application-default login`
 
-You can execute an import job from your local end by invoking the following script:
+You can execute an import job from your local end by invoking the script below. Note that instead of downloading a fresh version of this repo from GitHub, this script uses the locally downloaded/cloned current state of the repo by inferring the path to the `data` root directory. A side effect is that upon completion, the local GitHub repo may have other artifacts, e.g. output CSV/TMCF files produced. You may want to revert those files if they are not intended to be committed.
+
+Once the script runs to completion, the data directory's latest update is printed (along with the location on GCS) which can confirm whether the import actually produced new data. Note: it is a good idea to check the directory path printed to see if the expected import files are all there.
+
+Ensure this script is executed from the directory which contains `schedule_update_import.sh`, i.e. from `/data/import-automation/executor`.
 
 ```
 Run `./schedule_update_import.sh -u <config_project_id> <path_to_import> <import_script_args>`

--- a/import-automation/executor/README.md
+++ b/import-automation/executor/README.md
@@ -67,7 +67,7 @@ Run `./schedule_update_import.sh --help` for usage.
 `<path_to_import>` is the path to the import (relative to the root directory of the `data` repo), with the name of the import provided with a colon, e.g. `scripts/us_usda/quickstats:UsdaAgSurvey`.
 `import_script_args` is one string (enclosed by quotes) representing all the command line args to be provided to the import script, e.g. `"--start_year=2023 --another_flag=val"`.
 
-Example invokation:
+Example invocation:
 
 ```
 Run `./schedule_update_import.sh -u datcom-import-automation scripts/us_usda/quickstats:UsdaAgSurvey "--start_year=2023"`

--- a/import-automation/executor/schedule_update_import.py
+++ b/import-automation/executor/schedule_update_import.py
@@ -184,9 +184,7 @@ def main(_):
         logging.info("***** Beginning Update. Can take a while. *******")
         logging.info("*************************************************")
         res = dataclasses.asdict(
-            update(cfg,
-                   absolute_import_path,
-                   local_repo_dir=repo_dir))
+            update(cfg, absolute_import_path, local_repo_dir=repo_dir))
         logging.info("*************************************************")
         logging.info("*********** Update Complete. ********************")
         logging.info("*************************************************")

--- a/import-automation/executor/schedule_update_import.py
+++ b/import-automation/executor/schedule_update_import.py
@@ -1,0 +1,157 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import dataclasses
+import sys
+import os
+import logging
+import json
+from typing import List
+
+from absl import app
+from absl import flags
+from app import configs
+from app.executor import import_target
+from app.executor import import_executor
+from app.executor import cloud_scheduler
+from app.service import file_uploader
+from app.service import github_api
+from google.cloud import storage
+
+_FLAGS = flags.FLAGS
+
+flags.DEFINE_string('mode', '', 'Options: update or schedule.')
+flags.DEFINE_string('config_project_id', '', 'GCS Project for the config file.')
+flags.DEFINE_string('config_bucket', 'import-automation-configs', 'GCS bucket name for the config file.')
+flags.DEFINE_string('config_filename', 'configs.json', 'GCS filename for the config file.')
+
+flags.DEFINE_string(
+    'absolute_import_path', '',
+    'A string specifying the path of an import in the following format:'
+    '<path_to_directory_relative_to_repository_root>:<import_name>.'
+    'Example: scripts/us_usda/quickstats:UsdaAgSurvey')
+
+flags.DEFINE_string(
+    'import_script_args', '',
+    'One string of command line args for the import script,'
+    'e.g. "--flag1=value1 --flag2=value2"')
+
+_FLAGS(sys.argv)
+
+logging.basicConfig(level=logging.INFO)
+
+
+def _get_cloud_config() -> configs.ExecutorConfig:
+    logging.info('Getting cloud config.')
+    project_id = _FLAGS.config_project_id
+    bucket = _FLAGS.config_bucket
+    fname = _FLAGS.config_filename
+    logging.info(
+        f'\nProject ID: {project_id},\nBucket: {bucket};\nConfig Filename: {fname}'
+    )
+
+    bucket = storage.Client(project_id).bucket(bucket)
+    blob = bucket.blob(fname)
+    config_dict = json.loads(blob.download_as_string(client=None))
+
+    return configs.ExecutorConfig(**config_dict['configs'])
+
+
+def update(
+        cfg: configs.ExecutorConfig,
+        absolute_import_path: str,
+        import_script_args: List[str] = []) -> import_executor.ExecutionResult:
+    """Executes an update on the specified import.
+
+    Note: the sub-routine will clone the data repo at the most recent commit in
+    the branch master. Therefore, any local changes in the repo or import script
+    will not be reflected.
+
+    Args:
+        cfg: a configs.ExecutorConfig object with all the fields required for
+            the update script. Since it contains authentication information,
+            the configs should be read from a secure location, e.g. a Cloud
+            bucket, and then parsed and passed here as a configs.ExecutorConfig
+            object.
+        absolute_import_path: a string specifying the import's path in the
+            following format:
+                <path_to_directory_relative_to_repository_root>:<import_name>
+            example:
+                scripts/us_usda/quickstats:UsdaAgSurvey
+        import_script_args: a list of strings, each to be used as a command
+            line arg for the import script,
+            e.g. ['--flag1=value1', '--flag2=value2'].
+
+    Returns:
+        An import_executor.ExecutionResult object.
+    """
+    # Update the configs with user script args, if provided.
+    if import_script_args:
+        cfg.user_script_args = import_script_args
+
+    executor = import_executor.ImportExecutor(
+        uploader=file_uploader.GCSFileUploader(
+            project_id=cfg.gcs_project_id,
+            bucket_name=cfg.storage_prod_bucket_name),
+        github=github_api.GitHubRepoAPI(
+            repo_owner_username=cfg.github_repo_owner_username,
+            repo_name=cfg.github_repo_name,
+            auth_username=cfg.github_auth_username,
+            auth_access_token=cfg.github_auth_access_token),
+        config=cfg)
+
+    return executor.execute_imports_on_update(absolute_import_path)
+
+
+def main(_):
+    mode = _FLAGS.mode
+    absolute_import_path = _FLAGS.absolute_import_path
+    import_script_args = _FLAGS.import_script_args
+
+    if not _FLAGS.config_project_id:
+        raise Exception("Flag: config_project_if must be provided.")
+
+    if not mode or (mode not in ['update', 'schedule']):
+        raise Exception('Flag: mode must be set to \'update\' or \'schedule\'')
+
+    if not import_target.is_absolute_import_name(absolute_import_path):
+        raise Exception('Flag: absolute_import_path is invalid. Path should be like:'
+                      'scripts/us_usda/quickstats:UsdaAgSurvey')
+
+    # Converting string to list
+    args_list =  import_script_args.split(' ')
+    if type(args_list) != type([]):
+        raise Exception('Flag: import_script_args could not be parsed into a list.')
+
+    # Get the root repo directory (data). Assumption is that this script is being
+    # called from a path within the data repo.
+    cwd = os.getcwd()
+    repo_dir = cwd.split("data")[0] + "data"
+    logging.info(f'{mode} called with the following:')
+    logging.info(f'Config Project ID: {_FLAGS.config_project_id}')
+    logging.info(f'Import: {absolute_import_path}')
+    logging.info(f'Import script args: {args_list}')
+    logging.info(f'Repo root directory: {repo_dir}')
+
+
+    cfg = _get_cloud_config()
+    if mode == 'update':
+        res = dataclasses.asdict(update(cfg, absolute_import_path, import_script_args=args_list))
+        print(res)
+    elif mode == 'schedule':
+        # TODO: implement this.
+        pass
+
+
+if __name__ == '__main__':
+    app.run(main)

--- a/import-automation/executor/schedule_update_import.py
+++ b/import-automation/executor/schedule_update_import.py
@@ -197,6 +197,7 @@ def main(_):
     logging.info(f'Import script args: {args_list}')
     logging.info(f'Repo root directory: {repo_dir}')
 
+    # TODO: allow overriding/updating config params from a local config file as well.
     cfg = _get_cloud_config()
     if mode == 'update':
         logging.info("*************************************************")

--- a/import-automation/executor/schedule_update_import.sh
+++ b/import-automation/executor/schedule_update_import.sh
@@ -44,6 +44,6 @@ python3 -m venv .env
 . .env/bin/activate
 pip3 install --disable-pip-version-check -r requirements.txt
 
-python3 -m schedule_update_import --config_project_id=$CONFIG_PROJECT_ID --mode=$MODE --absolute_import_path=$IMPORT_PATH"
+python3 -m schedule_update_import --config_project_id=$CONFIG_PROJECT_ID --mode=$MODE --absolute_import_path=$IMPORT_PATH
 
 deactivate

--- a/import-automation/executor/schedule_update_import.sh
+++ b/import-automation/executor/schedule_update_import.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+function help {
+  echo "#Usage: -us <config_project_id> <absolute_import_path> <import_script_args>"
+  echo "## <config_project_id> is the GCP project ID where the config file is located." 
+  echo "## Update an import specified by <absolute_import_path>, e.g. scripts/us_usda/quickstats:UsdaAgSurvey"
+  echo "## Provide all args for the import script as one string, i.e. with quotes, e.g. \"--flag1=val1 --flag2=val2\""
+}
+
+if [[ $# -le 1 ]]; then
+  help
+  exit 1
+fi
+
+while getopts us OPTION; do
+  case $OPTION in
+    u)
+        MODE="update"
+        ;;
+    s)
+        MODE="schedule"
+        ;;
+    *)
+        help
+    esac
+done
+
+CONFIG_PROJECT_ID=$2
+IMPORT_PATH=$3
+IMPORT_SCRIPT_ARGS=$4
+
+python3 -m venv .env
+. .env/bin/activate
+pip3 install --disable-pip-version-check -r requirements.txt
+
+python3 -m schedule_update_import --config_project_id=$CONFIG_PROJECT_ID --mode=$MODE --absolute_import_path=$IMPORT_PATH --import_script_args="$IMPORT_SCRIPT_ARGS"
+
+deactivate

--- a/import-automation/executor/schedule_update_import.sh
+++ b/import-automation/executor/schedule_update_import.sh
@@ -18,6 +18,7 @@ function help {
   echo "## <config_project_id> is the GCP project ID where the config file is located." 
   echo "## Update an import specified by <absolute_import_path>, e.g. scripts/us_usda/quickstats:UsdaAgSurvey"
   echo "## Provide all args for the import script as one string, i.e. with quotes, e.g. \"--flag1=val1 --flag2=val2\""
+  exit 1
 }
 
 if [[ $# -le 1 ]]; then
@@ -42,10 +43,10 @@ CONFIG_PROJECT_ID=$2
 IMPORT_PATH=$3
 IMPORT_SCRIPT_ARGS=$4
 
-# python3 -m venv .env
-# . .env/bin/activate
-# pip3 install --disable-pip-version-check -r requirements.txt
+python3 -m venv .env
+. .env/bin/activate
+pip3 install --disable-pip-version-check -r requirements.txt
 
 python3 -m schedule_update_import --config_project_id=$CONFIG_PROJECT_ID --mode=$MODE --absolute_import_path=$IMPORT_PATH --import_script_args="$IMPORT_SCRIPT_ARGS"
 
-#deactivate
+deactivate

--- a/import-automation/executor/schedule_update_import.sh
+++ b/import-automation/executor/schedule_update_import.sh
@@ -42,10 +42,10 @@ CONFIG_PROJECT_ID=$2
 IMPORT_PATH=$3
 IMPORT_SCRIPT_ARGS=$4
 
-python3 -m venv .env
-. .env/bin/activate
-pip3 install --disable-pip-version-check -r requirements.txt
+# python3 -m venv .env
+# . .env/bin/activate
+# pip3 install --disable-pip-version-check -r requirements.txt
 
 python3 -m schedule_update_import --config_project_id=$CONFIG_PROJECT_ID --mode=$MODE --absolute_import_path=$IMPORT_PATH --import_script_args="$IMPORT_SCRIPT_ARGS"
 
-deactivate
+#deactivate

--- a/import-automation/executor/schedule_update_import.sh
+++ b/import-automation/executor/schedule_update_import.sh
@@ -14,11 +14,9 @@
 # limitations under the License.
 
 function help {
-  echo "#Usage: -us <config_project_id> <absolute_import_path> <import_script_args>"
+  echo "#Usage: -us <config_project_id> <absolute_import_path>"
   echo "## <config_project_id> is the GCP project ID where the config file is located." 
-  echo "## Update an import specified by <absolute_import_path>, e.g. scripts/us_usda/quickstats:UsdaAgSurvey"
-  echo "## Provide all args for the import script as one string, i.e. with quotes, e.g. \"--flag1=val1 --flag2=val2\""
-  exit 1
+  echo "## Update an import specified by <absolute_import_path>, e.g. scripts/us_usda/quickstats:UsdaAgSurvey"  exit 1
 }
 
 if [[ $# -le 1 ]]; then
@@ -41,12 +39,11 @@ done
 
 CONFIG_PROJECT_ID=$2
 IMPORT_PATH=$3
-IMPORT_SCRIPT_ARGS=$4
 
 python3 -m venv .env
 . .env/bin/activate
 pip3 install --disable-pip-version-check -r requirements.txt
 
-python3 -m schedule_update_import --config_project_id=$CONFIG_PROJECT_ID --mode=$MODE --absolute_import_path=$IMPORT_PATH --import_script_args="$IMPORT_SCRIPT_ARGS"
+python3 -m schedule_update_import --config_project_id=$CONFIG_PROJECT_ID --mode=$MODE --absolute_import_path=$IMPORT_PATH"
 
 deactivate


### PR DESCRIPTION
In this PR, we have:

1. A new script to trigger updates for imports.
2. Print some diagnostics at completion time
3. Use currently checked out repo instead of using the latest committed master branch (which happens via the Cloud Scheduler workflow).

Coming next:

- Ability to parse and set/override configs from a local file (including user script args)
- Similar flow for Scheduling imports on the Cloud Scheduler.
- More diagnostics.