### PR TITLE
[WDI Indicator Download] Provide a default filename for WDI download

### DIFF
--- a/scripts/world_bank/.gitignore
+++ b/scripts/world_bank/.gitignore
@@ -1,1 +1,2 @@
 preprocessed_source_csv
+download_indicators/*.csv

--- a/scripts/world_bank/wdi/download_indicators/wdi_download_indicators.py
+++ b/scripts/world_bank/wdi/download_indicators/wdi_download_indicators.py
@@ -9,7 +9,10 @@ from absl import flags
 import numpy as np
 import pandas as pd
 
-_OUT_PATH = flags.DEFINE_string('out_path', None, 'CNS path to write output.')
+# The output path should have a default filename.
+_OUT_DEFAULT_NAME = 'cleaned_wdi.csv'
+_OUT_PATH = flags.DEFINE_string('out_path', _OUT_DEFAULT_NAME,
+                                'CNS path to write output.')
 
 indicators = [
     'SP.POP.TOTL',
@@ -72,6 +75,7 @@ def DownloadAndParseCsvs() -> None:
   """
     dat = []
     for indicator in indicators:
+        print("IND ODWNLIADING....")
         resp = urllib.request.urlopen(
             f'http://api.worldbank.org/v2/country/all/indicator/{indicator}?source=2&downloadformat=csv'
         )
@@ -121,6 +125,8 @@ def DownloadAndParseCsvs() -> None:
             'unit',
         ],
     )
+    # Write to the _OUT_PATH which defaults to the output filename
+    # if no path is provided.
     with open(_OUT_PATH.value, 'w+') as f_out:
         out_df.to_csv(f_out, index=False)
 

--- a/scripts/world_bank/wdi/download_indicators/wdi_download_indicators.py
+++ b/scripts/world_bank/wdi/download_indicators/wdi_download_indicators.py
@@ -75,7 +75,7 @@ def DownloadAndParseCsvs() -> None:
   """
     dat = []
     for indicator in indicators:
-        print("IND ODWNLIADING....")
+        print(f'DOWNLOADING: {indicator}....')
         resp = urllib.request.urlopen(
             f'http://api.worldbank.org/v2/country/all/indicator/{indicator}?source=2&downloadformat=csv'
         )


### PR DESCRIPTION
During import automation testing, noticed that the script linked in the manifest expects a FLAG which is a path on CNS. That won't work for import automation so now adding a default filename to write the output to (locally). This output is then deposited to the correct GCS bucket. 

Tested using the local import automation update script and with this fix it works.