### PR TITLE
Remove versions for modules

### DIFF
--- a/scripts/earthengine/requirements.txt
+++ b/scripts/earthengine/requirements.txt
@@ -2,7 +2,7 @@
 bigquery
 dataclasses
 datacommons
-earthengine-api
+earthengine-api>=0.1.374
 geojson
 geopy
 google-cloud-logging


### PR DESCRIPTION
With upgrade to py3.11, use the latest version for all modules.