### PR TITLE
Add support for shell import scripts in automation

### DIFF
--- a/import-automation/executor/app/executor/import_executor.py
+++ b/import-automation/executor/app/executor/import_executor.py
@@ -687,12 +687,17 @@ def _get_script_interpreter(script: str, py_interpreter: str) -> str:
         interpreter for user script, such as python for .py, bash for .sh
     """
     if not script:
-        return py_interpreter
+        return None
 
-    cmd = script.split(' ')[0]
-    if cmd.endswith('.sh'):
-        # Use bash for shell scripts.
-        return 'bash'
+    base, ext = os.path.splitext(script.split(' ')[0])
+    match ext:
+        case '.py':
+            return py_interpreter
+        case '.sh':
+            return 'bash'
+        case _:
+            logging.info(f'Unknown extension for script: {script}.')
+            return None
 
     return py_interpreter
 
@@ -726,7 +731,9 @@ def _run_user_script(
       subprocess.TimeoutExpired: The user script did not finish
           within timeout.
   """
-    script_args = [interpreter_path]
+    script_args = []
+    if interpreter_path:
+      script_args.append(interpreter_path)
     script_args.extend(script_path.split(' '))
     if args:
         script_args.extend(args)

--- a/import-automation/executor/app/executor/import_executor.py
+++ b/import-automation/executor/app/executor/import_executor.py
@@ -333,6 +333,7 @@ class ImportExecutor:
 
     Args: See _import_one.
     """
+        import_name = import_spec['import_name']
         urls = import_spec.get('data_download_url')
         if urls:
             for url in urls:
@@ -370,20 +371,23 @@ class ImportExecutor:
                     )
                 else:
                     # Run import script locally.
+                    script_interpreter = _get_script_interpreter(
+                        script_path, interpreter_path)
                     process = _run_user_script(
-                        interpreter_path=interpreter_path,
+                        interpreter_path=script_interpreter,
                         script_path=script_path,
                         timeout=self.config.user_script_timeout,
                         args=self.config.user_script_args,
                         cwd=absolute_import_dir,
                         env=self.config.user_script_env,
+                        name=import_name,
                     )
                     _log_process(process=process)
                     process.check_returncode()
 
         inputs = self._upload_import_inputs(
             import_dir=absolute_import_dir,
-            output_dir=f'{relative_import_dir}/{import_spec["import_name"]}',
+            output_dir=f'{relative_import_dir}/{import_name}',
             version=version,
             import_spec=import_spec,
         )
@@ -527,7 +531,8 @@ def run_and_handle_exception(
 def _run_with_timeout_async(args: List[str],
                             timeout: float,
                             cwd: str = None,
-                            env: dict = None) -> subprocess.CompletedProcess:
+                            env: dict = None,
+                            name: str = None) -> subprocess.CompletedProcess:
     """Runs a command in a subprocess asynchronously and emits the stdout/stderr.
 
   Args:
@@ -543,8 +548,8 @@ def _run_with_timeout_async(args: List[str],
   """
     try:
         logging.info(
-            f'Launching async command: {args} with timeout {timeout} in {cwd}, env:'
-            f' {env}')
+            f'Launching async command for {name}: {args} '
+            f'with timeout {timeout} in {cwd}, env: {env}')
         start_time = time.time()
         stdout = []
         stderr = []
@@ -559,17 +564,20 @@ def _run_with_timeout_async(args: List[str],
         # Log output continuously until the command completes.
         for line in process.stderr:
             stderr.append(line)
-            logging.info(f'Process stderr: {line}')
+            logging.info(f'Process stderr:{name}: {line}')
         for line in process.stdout:
             stdout.append(line)
-            logging.info(f'Process stdout: {line}')
+            logging.info(f'Process stdout:{name}: {line}')
 
+        # Wait in case script has closed stderr/stdout early.
+        process.wait()
         end_time = time.time()
 
         return_code = process.returncode
         end_msg = (
-            f'Completed script: "{args}", Return code: {return_code}, time:'
-            f' {end_time - start_time:.3f} secs.\n')
+            f'Completed script:{name}: "{args}", '
+            f'Return code: {return_code}, '
+            f'time: {end_time - start_time:.3f} secs.\n')
         logging.info(end_msg)
         return subprocess.CompletedProcess(
             args=args,
@@ -580,8 +588,8 @@ def _run_with_timeout_async(args: List[str],
     except Exception as e:
         message = traceback.format_exc()
         logging.exception(
-            f'An unexpected exception was thrown: {e} when running {args}:'
-            f' {message}')
+            f'An unexpected exception was thrown: {e} when running {name}:'
+            f'{args}: {message}')
         return subprocess.CompletedProcess(
             args=args,
             returncode=1,
@@ -668,6 +676,27 @@ def _create_venv(requirements_path: Iterable[str], venv_dir: str,
         return os.path.join(venv_dir, 'bin/python3'), process
 
 
+def _get_script_interpreter(script: str, py_interpreter: str) -> str:
+    """Returns the interpreter for the script.
+
+    Args:
+        script: user script to be executed
+        py_interpreter: Path to python within virtual environment
+
+    Returns:
+        interpreter for user script, such as python for .py, bash for .sh
+    """
+    if not script:
+        return py_interpreter
+
+    cmd = script.split(' ')[0]
+    if cmd.endswith('.sh'):
+        # Use bash for shell scripts.
+        return 'bash'
+
+    return py_interpreter
+
+
 def _run_user_script(
     interpreter_path: str,
     script_path: str,
@@ -675,6 +704,7 @@ def _run_user_script(
     args: list = None,
     cwd: str = None,
     env: dict = None,
+    name: str = None,
 ) -> subprocess.CompletedProcess:
     """Runs a user Python script.
 
@@ -687,6 +717,7 @@ def _run_user_script(
         the command line.
       cwd: Current working directory of the process as a string.
       env: Dict of environment variables for the user script run.
+      name: Name of the script.
 
   Returns:
       subprocess.CompletedProcess object used to run the script.
@@ -699,7 +730,7 @@ def _run_user_script(
     script_args.extend(script_path.split(' '))
     if args:
         script_args.extend(args)
-    return _run_with_timeout_async(script_args, timeout, cwd, env)
+    return _run_with_timeout_async(script_args, timeout, cwd, env, name)
 
 
 def _clean_time(

--- a/import-automation/executor/app/executor/import_executor.py
+++ b/import-automation/executor/app/executor/import_executor.py
@@ -683,6 +683,7 @@ def _get_script_interpreter(script: str, py_interpreter: str) -> str:
 
     Returns:
         interpreter for user script, such as python for .py, bash for .sh
+        Returns None if the script has no extension.
     """
     if not script:
         return None

--- a/import-automation/executor/app/executor/import_executor.py
+++ b/import-automation/executor/app/executor/import_executor.py
@@ -547,9 +547,8 @@ def _run_with_timeout_async(args: List[str],
       Same exceptions as subprocess.run.
   """
     try:
-        logging.info(
-            f'Launching async command for {name}: {args} '
-            f'with timeout {timeout} in {cwd}, env: {env}')
+        logging.info(f'Launching async command for {name}: {args} '
+                     f'with timeout {timeout} in {cwd}, env: {env}')
         start_time = time.time()
         stdout = []
         stderr = []
@@ -574,10 +573,9 @@ def _run_with_timeout_async(args: List[str],
         end_time = time.time()
 
         return_code = process.returncode
-        end_msg = (
-            f'Completed script:{name}: "{args}", '
-            f'Return code: {return_code}, '
-            f'time: {end_time - start_time:.3f} secs.\n')
+        end_msg = (f'Completed script:{name}: "{args}", '
+                   f'Return code: {return_code}, '
+                   f'time: {end_time - start_time:.3f} secs.\n')
         logging.info(end_msg)
         return subprocess.CompletedProcess(
             args=args,
@@ -733,7 +731,7 @@ def _run_user_script(
   """
     script_args = []
     if interpreter_path:
-      script_args.append(interpreter_path)
+        script_args.append(interpreter_path)
     script_args.extend(script_path.split(' '))
     if args:
         script_args.extend(args)

--- a/import-automation/executor/schedule_update_import.py
+++ b/import-automation/executor/schedule_update_import.py
@@ -54,6 +54,8 @@ flags.DEFINE_string(
     'A string specifying the path of an import in the following format:'
     '<path_to_directory_relative_to_repository_root>:<import_name>.'
     'Example: scripts/us_usda/quickstats:UsdaAgSurvey')
+flags.DEFINE_string('config_override', _CONFIG_OVERRIDE_FILE,
+                    'Config file with overridden parameters.')
 
 _FLAGS(sys.argv)
 
@@ -301,8 +303,8 @@ def main(_):
     cfg.gcp_project_id = _FLAGS.gke_project_id
 
     logging.info(
-        f'Updating any config fields from local file: {_CONFIG_OVERRIDE_FILE}.')
-    cfg = _override_configs(_CONFIG_OVERRIDE_FILE, cfg)
+        f'Updating any config fields from local file: {_FLAGS.config_override}.')
+    cfg = _override_configs(_FLAGS.config_override, cfg)
 
     logging.info('Reading Cloud scheduler configs from GCS.')
     scheduler_config_dict = _get_cloud_config(_FLAGS.scheduler_config_filename)

--- a/import-automation/executor/schedule_update_import.py
+++ b/import-automation/executor/schedule_update_import.py
@@ -303,7 +303,8 @@ def main(_):
     cfg.gcp_project_id = _FLAGS.gke_project_id
 
     logging.info(
-        f'Updating any config fields from local file: {_FLAGS.config_override}.')
+        f'Updating any config fields from local file: {_FLAGS.config_override}.'
+    )
     cfg = _override_configs(_FLAGS.config_override, cfg)
 
     logging.info('Reading Cloud scheduler configs from GCS.')


### PR DESCRIPTION
Added the following features:
1. Support shell import scripts
2. Prefix import script log messages with import name for easier debugging in cloud log viewer 
3. Add command option for local config_override file for schedule_update_import.py
   --config_override

for eg to run a test import that copies files to a different GCS bucket, create a local file /tmp/config_override.josn with the setting:
```
{
  "configs" : {
      "storage_prod_bucket_name": "datcom-test-imports",
      "email_account": "test@google.com",
  }
}
```