### PR TITLE
Add GCS volume to executor container

### DIFF
--- a/import-automation/executor/app/configs.py
+++ b/import-automation/executor/app/configs.py
@@ -107,6 +107,8 @@ class ExecutorConfig:
     requirements_filename: str = 'requirements.txt'
     # ID of the location where Cloud Scheduler is hosted.
     scheduler_location: str = 'us-central1'
+    # Name of the GCS bucket for volume mount.
+    gcs_bucket_volume_mount: str = 'datcom-volume-mount'
     # Location of the GCS bucket volume mount.
     gcs_volume_mount_dir: str = '/mnt'
     # Location of the local git data repo.

--- a/import-automation/executor/app/configs.py
+++ b/import-automation/executor/app/configs.py
@@ -107,6 +107,8 @@ class ExecutorConfig:
     requirements_filename: str = 'requirements.txt'
     # ID of the location where Cloud Scheduler is hosted.
     scheduler_location: str = 'us-central1'
+    # Location of the GCS bucket volume mount.
+    gcs_volume_mount_dir: str = '/mnt'
     # Location of the local git data repo.
     local_repo_dir: str = '/data'
     # Location of the import tool jar.

--- a/import-automation/executor/app/executor/cloud_run.py
+++ b/import-automation/executor/app/executor/cloud_run.py
@@ -28,8 +28,9 @@ from google.protobuf import duration_pb2
 
 
 def create_or_update_cloud_run_job(project_id: str, location: str, job_id: str,
-                                   image: str, env_vars: dict, args: list,
-                                   resources: dict, timeout: int) -> run_v2.Job:
+                                   image: str, mount_bucket: str,
+                                   env_vars: dict, args: list, resources: dict,
+                                   timeout: int) -> run_v2.Job:
     """Creates a new cloud run job or updates an existing one.
 
   If the jobs exists, the container is updated with new image and environment
@@ -41,6 +42,7 @@ def create_or_update_cloud_run_job(project_id: str, location: str, job_id: str,
     location: Region for the execution, such as 'us-central1'
     job_id: Name of the job
     image: Container image URL such as 'gcr.io/your-project/your-image:latest'
+    mount_bucket: Name of GCS bucket to mount as a volume
     env_vars: dict of environment variables as {'VAR': '<value>'}
     args: list of command line arguments
     resources: cpu/memory resources
@@ -62,7 +64,7 @@ def create_or_update_cloud_run_job(project_id: str, location: str, job_id: str,
     res = run_v2.types.ResourceRequirements(limits=resources)
     mount = run_v2.types.VolumeMount(name='datcom-mount-volume',
                                      mount_path='/mnt')
-    source = run_v2.GCSVolumeSource(bucket='datcom-mount-volume')
+    source = run_v2.GCSVolumeSource(bucket=mount_bucket)
     volume = run_v2.types.Volume(name='datcom-mount-volume', gcs=source)
     container = run_v2.Container(image=image,
                                  env=env,

--- a/import-automation/executor/app/executor/cloud_run.py
+++ b/import-automation/executor/app/executor/cloud_run.py
@@ -60,10 +60,10 @@ def create_or_update_cloud_run_job(project_id: str, location: str, job_id: str,
         env.append(run_v2.EnvVar(name=var, value=value))
 
     res = run_v2.types.ResourceRequirements(limits=resources)
-    mount = run_v2.types.VolumeMount(name='datcom-import-volume',
+    mount = run_v2.types.VolumeMount(name='datcom-mount-volume',
                                      mount_path='/mnt')
-    source = run_v2.GCSVolumeSource(bucket='dc-import-volume')
-    volume = run_v2.types.Volume(name='datcom-import-volume', gcs=source)
+    source = run_v2.GCSVolumeSource(bucket='datcom-mount-volume')
+    volume = run_v2.types.Volume(name='datcom-mount-volume', gcs=source)
     container = run_v2.Container(image=image,
                                  env=env,
                                  resources=res,

--- a/import-automation/executor/app/executor/cloud_run_simple_import.py
+++ b/import-automation/executor/app/executor/cloud_run_simple_import.py
@@ -38,6 +38,7 @@ _DEFAULT_SIMPLE_IMAGE = os.environ.get(
     'DOCKER_IMAGE', 'gcr.io/datcom-ci/datacommons-simple:stable')
 _DEFAULT_LOCATION = os.environ.get('CLOUD_REGION', 'us-central1')
 _DEFAULT_GCS_BUCKET = os.environ.get('GCS_BUCKET', 'datcom-prod-imports')
+_DEFAULT_VOLUME_MOUNT = os.environ.get('VOLUME_MOUNT', 'datcom-volume-mount')
 _DEFAULT_CONFIG_PREFIX = 'import_config'
 
 # Path for simple import config spec under data/scripts/simple
@@ -136,6 +137,7 @@ def cloud_run_simple_import_job(
     project_id: str = _DEFAULT_PROJECT,
     location: str = _DEFAULT_LOCATION,
     image: str = _DEFAULT_SIMPLE_IMAGE,
+    volume_mount: str = _DEFAULT_VOLUME_MOUNT,
 ) -> str:
     """Create and run a Cloud Run job for simple a import.
 
@@ -151,6 +153,7 @@ def cloud_run_simple_import_job(
       account for the project should have access to the GCS folder for output.
     location: Region for the cloud run instance.
     image: container image URL for the simple-importer.
+    volume_mount: GCS bucket for volume mount;
 
   Returns:
     Output directory with the script outputs.
@@ -191,8 +194,8 @@ def cloud_run_simple_import_job(
     resources = {}
     args = []
     job = cloud_run.create_or_update_cloud_run_job(project_id, location, job_id,
-                                                   image, env_vars, args,
-                                                   resources)
+                                                   image, volume_mount,
+                                                   env_vars, args, resources)
     if not job:
         logging.error(
             f'Failed to setup cloud run job {job_id} for {config_file}')

--- a/import-automation/executor/app/executor/import_executor.py
+++ b/import-automation/executor/app/executor/import_executor.py
@@ -459,14 +459,14 @@ class ImportExecutor:
             import_name = import_spec['import_name']
             mount_path = os.path.join(self.config.gcs_volume_mount_dir,
                                       import_name)
-            out_path = os.path.join(absolute_import_dir, 'output')
+            out_path = os.path.join(absolute_import_dir, 'gcs_output')
             logging.info(f'Mount path: {mount_path}, Out path: {out_path}')
             if os.path.exists(mount_path):
                 shutil.rmtree(mount_path)
             if os.path.lexists(out_path):
                 os.unlink(out_path)
             os.makedirs(mount_path, exist_ok=True)
-            os.symlink(mount_path, out_path, True)
+            os.symlink(mount_path, out_path, target_is_directory=True)
             simple_job = cloud_run_simple_import.get_simple_import_job_id(
                 import_spec, script_path)
             if simple_job:

--- a/import-automation/executor/app/executor/import_executor.py
+++ b/import-automation/executor/app/executor/import_executor.py
@@ -21,6 +21,7 @@ import glob
 import json
 import logging
 import os
+import shutil
 import sys
 import subprocess
 import tempfile
@@ -455,6 +456,17 @@ class ImportExecutor:
         script_paths = import_spec.get('scripts')
         for path in script_paths:
             script_path = os.path.join(absolute_import_dir, path)
+            import_name = import_spec['import_name']
+            mount_path = os.path.join(self.config.gcs_volume_mount_dir,
+                                      import_name)
+            out_path = os.path.join(absolute_import_dir, 'output')
+            logging.info(f'Mount path: {mount_path}, Out path: {out_path}')
+            if os.path.exists(mount_path):
+                shutil.rmtree(mount_path)
+            if os.path.lexists(out_path):
+                os.unlink(out_path)
+            os.makedirs(mount_path, exist_ok=True)
+            os.symlink(mount_path, out_path, True)
             simple_job = cloud_run_simple_import.get_simple_import_job_id(
                 import_spec, script_path)
             if simple_job:

--- a/import-automation/executor/app/executor/scheduler_job_manager.py
+++ b/import-automation/executor/app/executor/scheduler_job_manager.py
@@ -138,7 +138,8 @@ def create_or_update_import_schedule(absolute_import_name: str,
         env_vars = {}
         job = cloud_run.create_or_update_cloud_run_job(
             config.gcp_project_id, config.scheduler_location, job_name,
-            docker_image, env_vars, args, resources, timeout)
+            docker_image, config.gcs_bucket_volume_mount, env_vars, args,
+            resources, timeout)
         job_id = job.name.rsplit('/', 1)[1]
         if not job:
             logging.error(


### PR DESCRIPTION
This PR adds a GCS bucket as a volume mount to the import executor docker container. Since the local storage for the import executor docker container is limited (cloud run uses memory as the local storage), GCS volume allows import scripts to download larger files to the external volume. The GCS bucket includes an import specific folder for each import to allow separation with a symlink to 'gcs_output' in the import script directory under data repo in the container. 