### PR TITLE
updated the flag name of config

### DIFF
--- a/tools/statvar_importer/stat_var_processor.py
+++ b/tools/statvar_importer/stat_var_processor.py
@@ -2992,7 +2992,7 @@ def main(_):
         StatVarDataProcessor,
         input_data=_FLAGS.input_data,
         output_path=_FLAGS.output_path,
-        config=_FLAGS.config,
+        config=_FLAGS.config_file,
         pv_map_files=_FLAGS.pv_map,
         parallelism=_FLAGS.parallelism,
     )


### PR DESCRIPTION
Corrected AttributeError: config in stat_var_processor.py (line 2995). The code was attempting to access a flag named config from _FLAGS, but the declared flag in config_flags.py is config_file. This commit updates the access to FLAGS.config_file to resolve the error.