### PR TITLE
[Draft] Fix issues in CDC imports scripts

### DIFF
--- a/import-automation/executor/Dockerfile
+++ b/import-automation/executor/Dockerfile
@@ -19,21 +19,7 @@ ARG build_type=cloud
 
 # build base image with all the dependencies installed
 FROM python:3.12.8 as base
-RUN apt-get update && apt-get install -y jq \
-gnupg \
-apt-transport-https \
-ca-certificates \
-libglib2.0-0 \
-libnss3 \
-libgconf-2-4 \
-libatk1.0-0 \
-libgtk-3-0 \
-libx11-6 \
-libasound2 \
-fonts-liberation \
-xdg-utils \
-chromium \
-chromium-driver
+RUN apt-get update && apt-get install -y jq
 ENV JAVA_HOME=/usr/local/openjdk-17
 COPY --from=openjdk:17-slim $JAVA_HOME $JAVA_HOME
 ENV PATH="${JAVA_HOME}/bin:${PATH}"

--- a/import-automation/executor/cloud_run_import_test.sh
+++ b/import-automation/executor/cloud_run_import_test.sh
@@ -19,7 +19,7 @@ mount_bucket=datcom-ci-test
 data_repo=$(realpath $(dirname $0)/../../)
 cpus=2
 memory=4Gi
-timeout=30m
+timeout=5h
 
 echo "Building docker image $1"
 DOCKER_BUILDKIT=1 docker buildx build --build-context data=$data_repo --build-arg build_type=local -f Dockerfile . -t $artifact_registry/$1:latest

--- a/import-automation/executor/requirements.txt
+++ b/import-automation/executor/requirements.txt
@@ -52,3 +52,4 @@ xlsxwriter
 zipp
 netCDF4
 xmltodict
+tenacity

--- a/scripts/us_cdc/environmental_health_toxicology/download_files.py
+++ b/scripts/us_cdc/environmental_health_toxicology/download_files.py
@@ -41,7 +41,8 @@ def download_files(importname, configs):
         with requests.get(url, stream=True) as response, file_util.FileIO(filename, 'wb') as f:
             response.raise_for_status()
             if response.status_code == 200:
-                for chunk in response.iter_content(chunk_size=8192):
+                chunk_size = 10 * 1024 * 1024 # 10 MB
+                for chunk in response.iter_content(chunk_size=chunk_size):
                     f.write(chunk)
                     downloaded_bytes += len(chunk)
                     logging.info(f"Downloaded {downloaded_bytes} bytes from {url}")

--- a/scripts/us_cdc/environmental_health_toxicology/download_files.py
+++ b/scripts/us_cdc/environmental_health_toxicology/download_files.py
@@ -87,7 +87,7 @@ def main(_):
     """Main function to download the csv files."""
     global _INPUT_FILE_PATH
     _INPUT_FILE_PATH = os.path.join(_FLAGS.input_file_path)
-    _INPUT_FILE_PATH = os.path.join(_MODULE_DIR, _FLAGS.input_file_path)
+    _INPUT_FILE_PATH = os.path.join(_MODULE_DIR, 'gcs_output', _FLAGS.input_file_path)
     Path(_INPUT_FILE_PATH).mkdir(parents=True, exist_ok=True)
     importname = sys.argv[1]
     logging.info(f'Loading config: {_FLAGS.config_file}')

--- a/scripts/us_cdc/environmental_health_toxicology/manifest.json
+++ b/scripts/us_cdc/environmental_health_toxicology/manifest.json
@@ -15,19 +15,19 @@
         "import_inputs": [
           {
             "template_mcf": "PM25CensusTractPollution.tmcf",
-            "cleaned_csv": "output/PM2.5CensusTract_0.csv"
+            "cleaned_csv": "gcs_output/PM2.5CensusTract_0.csv"
           },
           {
             "template_mcf": "PM25CensusTractPollution.tmcf",
-            "cleaned_csv": "output/PM2.5CensusTract_1.csv"
+            "cleaned_csv": "gcs_output/PM2.5CensusTract_1.csv"
           },
           {
             "template_mcf": "PM25CensusTractPollution.tmcf",
-            "cleaned_csv": "output/PM2.5CensusTract_2.csv"
+            "cleaned_csv": "gcs_output/PM2.5CensusTract_2.csv"
           },
           {
             "template_mcf": "PM25CensusTractPollution.tmcf",
-            "cleaned_csv": "output/PM2.5CensusTract_3.csv"
+            "cleaned_csv": "gcs_output/PM2.5CensusTract_3.csv"
           }
 
         ],
@@ -48,19 +48,19 @@
         "import_inputs": [
           {
             "template_mcf": "OzoneCensusTractPollution.tmcf",
-            "cleaned_csv": "output/Census_Tract_Level_Ozone_Concentrations_0.csv"
+            "cleaned_csv": "gcs_output/Census_Tract_Level_Ozone_Concentrations_0.csv"
           },
           {
             "template_mcf": "OzoneCensusTractPollution.tmcf",
-            "cleaned_csv": "output/Census_Tract_Level_Ozone_Concentrations_1.csv"
+            "cleaned_csv": "gcs_output/Census_Tract_Level_Ozone_Concentrations_1.csv"
           },
           {
             "template_mcf": "OzoneCensusTractPollution.tmcf",
-            "cleaned_csv": "output/Census_Tract_Level_Ozone_Concentrations_2.csv"
+            "cleaned_csv": "gcs_output/Census_Tract_Level_Ozone_Concentrations_2.csv"
           },
           {
             "template_mcf": "OzoneCensusTractPollution.tmcf",
-            "cleaned_csv": "output/Census_Tract_Level_Ozone_Concentrations_3.csv"
+            "cleaned_csv": "gcs_output/Census_Tract_Level_Ozone_Concentrations_3.csv"
           }
           
         ],
@@ -79,7 +79,7 @@
         "import_inputs": [
           {
             "template_mcf": "PM25CountyPollution.tmcf",
-            "cleaned_csv": "output/PM25county.csv"
+            "cleaned_csv": "gcs_output/PM25county.csv"
           }
           
         ],
@@ -98,7 +98,7 @@
         "import_inputs": [
           {
             "template_mcf": "OzoneCountyPollution.tmcf",
-            "cleaned_csv": "output/OzoneCounty.csv"
+            "cleaned_csv": "gcs_output/OzoneCounty.csv"
           }
           
         ],


### PR DESCRIPTION
(Draft PR to get early feedback).

This PR fixes the failing download scripts related to CDC imports. At present, the Cloud Run jobs are failing due to memory issues given the large size of import files. It is caused by:

1. No GCS mounts - Since Cloud Run's disk space is limited, we should mount the output path of the downloaded files to a GCS bucket. The script presently attempts to download it to local disk directly and is failing.

2. Storing file in memory - The script in its present form is first downloading the entire content to memory first and then writing to the file. This is problematic for large files which don't fit into memory.  So the download logic has been refactored to process in chunks. 