### PR TITLE
fix: Resolve ModuleNotFoundError in import executor

### DIFF
--- a/import-automation/executor/main.py
+++ b/import-automation/executor/main.py
@@ -20,6 +20,11 @@ import os
 import sys
 import time
 
+REPO_DIR = os.path.dirname(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.append(REPO_DIR)
+sys.path.append(os.path.join(REPO_DIR, 'util'))
+
 from absl import flags
 from absl import app
 
@@ -29,10 +34,6 @@ from app.service import file_uploader
 from app.service import github_api
 from app.service import email_notifier
 import dataclasses
-
-REPO_DIR = os.path.dirname(
-    os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-sys.path.append(os.path.join(REPO_DIR, 'util'))
 
 from log_util import log_metric, configure_cloud_logging
 from cloudrun_util import running_on_cloudrun


### PR DESCRIPTION
The CI check is failing on master branch with a ModuleNotFoundError because the `tools` module was not added to the Python path before application-level imports were attempted.

This PR fixes it by making two changes:
1. The project's root directory `REPO_DIR` is added to the Python path, ensuring the `tools` module is discoverable.
2. The `sys.path` modification is moved to the top of the file, ensuring that all necessary modules are discoverable before they are imported.