### PR TITLE
fix(validation): move flag definitions to main block

### DIFF
--- a/tools/import_validation/runner.py
+++ b/tools/import_validation/runner.py
@@ -28,15 +28,6 @@ from .util import filter_dataframe
 from .result import ValidationResult, ValidationStatus
 
 _FLAGS = flags.FLAGS
-flags.DEFINE_string('validation_config', 'validation_config.json',
-                    'Path to the validation config file.')
-flags.DEFINE_string('differ_output', None,
-                    'Path to the differ output data file.')
-flags.DEFINE_string('stats_summary', None,
-                    'Path to the stats summary report file.')
-flags.DEFINE_string('validation_output', None,
-                    'Path to the validation output file.')
-flags.mark_flag_as_required('validation_output')
 
 
 class ValidationRunner:
@@ -202,4 +193,13 @@ def main(_):
 
 
 if __name__ == '__main__':
+    flags.DEFINE_string('validation_config', 'validation_config.json',
+                        'Path to the validation config file.')
+    flags.DEFINE_string('differ_output', None,
+                        'Path to the differ output data file.')
+    flags.DEFINE_string('stats_summary', None,
+                        'Path to the stats summary report file.')
+    flags.DEFINE_string('validation_output', None,
+                        'Path to the validation output file.')
+    flags.mark_flag_as_required('validation_output')
     app.run(main)


### PR DESCRIPTION
Moves the absl flag definitions in the validation runner to the `if __name__ == '__main__':` block.

This prevents the flags from being registered when the ValidationRunner is imported programmatically, which was causing flag parsing errors in CI run of the import automation executor.

Follow-up of https://github.com/datacommonsorg/data/pull/1519 and https://github.com/datacommonsorg/data/pull/1521.