### PR TITLE
fix(validation): relax constraints around file existence

### DIFF
--- a/tools/import_validation/runner.py
+++ b/tools/import_validation/runner.py
@@ -28,15 +28,6 @@ from .util import filter_dataframe
 from .result import ValidationResult, ValidationStatus
 
 _FLAGS = flags.FLAGS
-flags.DEFINE_string('validation_config', 'validation_config.json',
-                    'Path to the validation config file.')
-flags.DEFINE_string('differ_output', None,
-                    'Path to the differ output data file.')
-flags.DEFINE_string('stats_summary', None,
-                    'Path to the stats summary report file.')
-flags.DEFINE_string('validation_output', None,
-                    'Path to the validation output file.')
-flags.mark_flag_as_required('validation_output')
 
 
 class ValidationRunner:
@@ -202,4 +193,13 @@ def main(_):
 
 
 if __name__ == '__main__':
+    flags.DEFINE_string('validation_config', 'validation_config.json',
+                        'Path to the validation config file.')
+    flags.DEFINE_string('differ_output', None,
+                        'Path to the differ output data file.')
+    flags.DEFINE_string('stats_summary', None,
+                        'Path to the stats summary report file.')
+    flags.DEFINE_string('validation_output', None,
+                        'Path to the validation output file.')
+    flags.mark_flag_as_required('validation_output')
     app.run(main)


### PR DESCRIPTION
I am not sure if this PR is necessary, but I creating a draft version of it just in case it might be needed.

This PR relaxes constraints on file existence of the differ file during the instantiation. This might be necessary when the import is run for the first time and the differ tool doesn't have existing data to diff with. This is a re-implementation of https://github.com/datacommonsorg/data/pull/1464 as it's changes got lost after merging #1428.