### PR TITLE
Add spanner ingestion workflow

### DIFF
--- a/import-automation/workflow/cloudbuild.yaml
+++ b/import-automation/workflow/cloudbuild.yaml
@@ -1,0 +1,10 @@
+# gcloud builds submit --config=cloudbuild.yaml . --project=datcom-import-automation-prod 
+
+steps:
+- id: 'spanner-ingestion-workflow'
+  name: 'gcr.io/cloud-builders/gcloud'
+  args: ['workflows', 'deploy', 'spanner-ingestion-workflow', '--source', 'spanner-ingestion-workflow.yaml']
+
+- id: 'spanner-ingestion-helper'
+  name: 'gcr.io/cloud-builders/gcloud'
+  args: ['functions', 'deploy', 'spanner-ingestion-helper', '--runtime', 'python312', '--source', 'helper', '--no-allow-unauthenticated', '--trigger-http', '--entry-point', 'ingestion_helper']

--- a/import-automation/workflow/helper/main.py
+++ b/import-automation/workflow/helper/main.py
@@ -1,0 +1,66 @@
+import functions_framework
+from spanner_client import SpannerClient
+from flask import jsonify
+
+_PROJECT_ID = 'datcom-store'
+_SPANNER_INSTANCE_ID = 'dc-kg-test'
+_SPANNER_DATABASE_ID = 'dc_graph_import'
+
+
+def _validate_params(request_json, required_params):
+    for param in required_params:
+        if param not in request_json:
+            return f"'{param}' parameter is missing"
+    return None
+
+
+@functions_framework.http
+def ingestion_helper(request):
+    """
+    HTTP Cloud Function with helper routines for Spanner ingestion workflow.
+    """
+    request_json = request.get_json(silent=True)
+    if not request_json:
+        return ('Request is not a valid JSON', 400)
+
+    validation_error = _validate_params(request_json, ['actionType'])
+    if validation_error:
+        return (validation_error, 400)
+
+    actionType = request_json['actionType']
+    spanner = SpannerClient(_PROJECT_ID, _SPANNER_INSTANCE_ID,
+                            _SPANNER_DATABASE_ID)
+    if actionType == 'get_import_status':
+        imports = spanner.get_import_status()
+        return jsonify(imports)
+    elif actionType == 'acquire_ingestion_lock':
+        validation_error = _validate_params(request_json,
+                                            ['workflowId', 'timeout'])
+        if validation_error:
+            return (validation_error, 400)
+        workflow = request_json['workflowId']
+        timeout = request_json['timeout']
+        status = spanner.acquire_lock(workflow, timeout)
+        if not status:
+            return ('Failed to acquire lock', 500)
+        return ('Lock acquired', 200)
+    elif actionType == 'release_ingestion_lock':
+        validation_error = _validate_params(request_json, ['workflowId'])
+        if validation_error:
+            return (validation_error, 400)
+        workflow = request_json['workflowId']
+        status = spanner.release_lock(workflow)
+        if not status:
+            return ('Failed to release lock', 500)
+        return ('Lock released', 200)
+    elif actionType == 'update_import_status':
+        validation_error = _validate_params(request_json,
+                                            ['importList', 'workflowId'])
+        if validation_error:
+            return (validation_error, 400)
+        imports = request_json['importList']
+        workflow = request_json['workflowId']
+        spanner.update_import_status(workflow, imports)
+        return ('Updated import status', 200)
+    else:
+        return (f'Unknown actionType: {actionType}', 400)

--- a/import-automation/workflow/helper/requirements.txt
+++ b/import-automation/workflow/helper/requirements.txt
@@ -1,0 +1,2 @@
+functions-framework==3.*
+google-cloud-spanner

--- a/import-automation/workflow/helper/spanner_client.py
+++ b/import-automation/workflow/helper/spanner_client.py
@@ -1,0 +1,160 @@
+import logging
+from google.cloud import spanner
+from google.cloud.spanner_v1 import Transaction
+from google.cloud.spanner_v1.param_types import STRING, TIMESTAMP, Array
+from datetime import datetime, timezone
+
+logging.getLogger().setLevel(logging.INFO)
+
+
+class SpannerClient:
+    """
+    Spanner client to handle tasks like acquiring/releasing lock 
+    and getting/updating import statuses.
+    """
+    _LOCK_ID = "global_ingestion_lock"
+
+    def __init__(self, project_id: str, instance_id: str, database_id: str):
+        """Initializes a Spanner client and connects to a specific database."""
+        spanner_client = spanner.Client(
+            project=project_id, client_options={'quota_project_id': project_id})
+        instance = spanner_client.instance(instance_id)
+        database = instance.database(database_id)
+        logging.info(f"Successfully initialized database: {database.name}")
+        self.database = database
+
+    def acquire_lock(self, workflow_id: str, timeout: int) -> bool:
+        """Attempts to acquire the global ingestion lock."""
+        logging.info(f"Attempting to acquire lock for {workflow_id}")
+
+        def _acquire(transaction: Transaction) -> bool:
+            sql = "SELECT LockOwner, AcquiredTimestamp FROM IngestionLock WHERE LockID = @lockId"
+            params = {"lockId": self._LOCK_ID}
+            param_types = {"lockId": STRING}
+
+            current_owner, acquired_at = None, None
+            results = transaction.execute_sql(sql, params, param_types)
+            for row in results:
+                current_owner, acquired_at = row[0], row[1]
+
+            lock_is_available = False
+            if current_owner is None:
+                lock_is_available = True
+            else:
+                timeout_threshold = datetime.now(timezone.utc) - acquired_at
+                if timeout_threshold.total_seconds() > timeout:
+                    logging.info(
+                        f"Stale lock found, owned by {current_owner}. Acquiring."
+                    )
+                    lock_is_available = True
+            if lock_is_available:
+                update_sql = """
+                    UPDATE IngestionLock
+                    SET LockOwner = @workflowId, AcquiredTimestamp = PENDING_COMMIT_TIMESTAMP()
+                    WHERE LockID = @lockId
+                """
+                transaction.execute_update(update_sql,
+                                           params={
+                                               "workflowId": workflow_id,
+                                               "lockId": self._LOCK_ID
+                                           },
+                                           param_types={
+                                               "workflowId": STRING,
+                                               "lockId": STRING
+                                           })
+                logging.info(f"Lock successfully acquired by {workflow_id}")
+                return True
+            else:
+                logging.info(f"Lock is currently held by {current_owner}")
+                return False
+
+        return self.database.run_in_transaction(_acquire)
+
+    def release_lock(self, workflow_id: str) -> bool:
+        """Releases the global lock."""
+        logging.info(f"Attempting to release lock for {workflow_id}")
+
+        def _release(transaction: Transaction) -> None:
+            sql = "SELECT LockOwner, AcquiredTimestamp FROM IngestionLock WHERE LockID = @lockId"
+            params = {"lockId": self._LOCK_ID}
+            param_types = {"lockId": STRING}
+
+            current_owner = None
+            results = transaction.execute_sql(sql, params, param_types)
+            for row in results:
+                current_owner = row[0]
+
+            if current_owner == workflow_id:
+                sql = """
+                    UPDATE IngestionLock
+                    SET LockOwner = NULL, AcquiredTimestamp = NULL
+                    WHERE LockID = @lockId
+                """
+                transaction.execute_update(sql,
+                                           params={"lockId": self._LOCK_ID},
+                                           param_types={"lockId": STRING})
+                logging.info(f"Lock successfully released by {workflow_id}")
+                return True
+            else:
+                logging.info(f"Lock is currently held by {current_owner}")
+                return False
+
+        return self.database.run_in_transaction(_release)
+
+    def get_import_status(self) -> list:
+        """Get the list of pending imports to ingest."""
+        pending_imports = []
+        sql = "SELECT ImportName, Latestversion FROM ImportStatus WHERE State = 'PENDING'"
+        # Use a read-only snapshot for this query
+        with self.database.snapshot() as snapshot:
+            results = snapshot.execute_sql(sql)
+            for row in results:
+                import_json = {}
+                import_json['importName'] = row[0]
+                import_json['latestVersion'] = row[1]
+                pending_imports.append(import_json)
+
+        logging.info(f"Found {len(pending_imports)} import jobs as PENDING.")
+        return pending_imports
+
+    def update_import_status(self, workflow_id: str, import_list: list) -> None:
+        """Atomically marks pending imports as DONE and records the ingestion event."""
+        succeeded_imports = []
+        if not import_list:
+            return
+        for import_json in import_list:
+            succeeded_imports.append(import_json['importName'])
+
+        def _record(transaction: Transaction) -> None:
+            # 1. Update the ImportStatus table
+            update_sql = "UPDATE ImportStatus SET State = 'DONE', JobId = @workflowId, UpdateTimestamp = PENDING_COMMIT_TIMESTAMP() WHERE ImportName IN UNNEST(@importNames)"
+            updated_rows = transaction.execute_update(
+                update_sql,
+                params={
+                    "importNames": succeeded_imports,
+                    "workflowId": workflow_id
+                },
+                param_types={
+                    "importNames": Array(STRING),
+                    "workflowId": STRING
+                })
+            logging.info(f"Marked {updated_rows} import jobs as DONE.")
+
+            # 2. Insert into the IngestionHistory table
+            insert_sql = """
+                INSERT INTO IngestionHistory (CompletionTimestamp, WorkflowExecutionID, IngestedImports)
+                VALUES (PENDING_COMMIT_TIMESTAMP(), @workflowId, @importNames)
+            """
+            transaction.execute_update(insert_sql,
+                                       params={
+                                           "workflowId": workflow_id,
+                                           "importNames": succeeded_imports
+                                       },
+                                       param_types={
+                                           "workflowId": STRING,
+                                           "importNames": Array(STRING)
+                                       })
+            logging.info(
+                f"Updated ingestion history table for workflow {workflow_id}")
+
+        self.database.run_in_transaction(_record)

--- a/import-automation/workflow/spanner-ingestion-workflow.yaml
+++ b/import-automation/workflow/spanner-ingestion-workflow.yaml
@@ -1,0 +1,156 @@
+main:
+  params: [args]
+  steps:
+    - invoke_ingestion_workflow:
+        try:
+          #call: googleapis.workflowexecutions.v1.projects.locations.workflows.executions.run
+          call: spanner_ingestion_workflow
+          args:
+            workflow_id: 'spanner-ingestion-workflow' 
+          result: workflow_result
+        except:
+          as: e
+          steps:
+            - clean_up:
+                call: http.post
+                args:
+                  url: 'https://spanner-ingestion-helper-965988403328.us-central1.run.app'
+                  auth:
+                    type: OIDC
+                  body:
+                    actionType: release_ingestion_lock
+                    workflowId: '${sys.get_env("GOOGLE_CLOUD_WORKFLOW_EXECUTION_ID")}'
+                result: function_response
+            - fail_workflow:
+                raise: ${e}
+    - return_result:
+        return: ${workflow_result}
+
+# This sub-workflow performs the following steps
+# - Acquire ingestion lock
+# - Get the list of pending imports
+# - Run dataflow ingestion job
+# - Update import status in spanner
+# - Release ingestion lock
+spanner_ingestion_workflow:
+  params: [workflow_id]
+  steps:
+    - init:
+        assign:
+          - lock_timeout: 3600 #seconds
+          - wait_period: 300 #seconds
+          - project_id: 'datcom-import-automation-prod'
+          - dataflow_job_name: 'ingestion-job'
+          - dataflow_gcs_path: 'gs://datcom-templates/templates/flex/ingestion.json'
+          - dataflow_location: 'us-central1'
+          - spanner_database_id: 'dc_graph_import'
+          - function_url: 'https://spanner-ingestion-helper-965988403328.us-central1.run.app'
+    - acquire_ingestion_lock:
+        call: http.post
+        args:
+          url: ${function_url}
+          auth:
+            type: OIDC
+          body:
+            actionType: acquire_ingestion_lock
+            workflowId: '${sys.get_env("GOOGLE_CLOUD_WORKFLOW_EXECUTION_ID")}'
+            timeout: ${lock_timeout}
+        result: lock_status
+    - get_import_status:
+        call: http.post
+        args:
+          url: ${function_url}
+          auth:
+            type: OIDC
+          body:
+            actionType: get_import_status
+        result: import_status
+    - run_ingestion_job:
+        call: run_dataflow_job
+        args:
+          import_list: '${json.encode_to_string(import_status.body)}'
+          project_id: ${project_id}
+          job_name: ${dataflow_job_name}
+          template_gcs_path: ${dataflow_gcs_path}
+          location: ${dataflow_location}
+          spanner_database_id: ${spanner_database_id}
+          wait_period: ${wait_period}
+        result: job_status
+    - update_import_status:
+        call: http.post
+        args:
+          url: ${function_url}
+          auth:
+            type: OIDC
+          body:
+            actionType: update_import_status
+            workflowId: '${sys.get_env("GOOGLE_CLOUD_WORKFLOW_EXECUTION_ID")}'
+            importList: '${import_status.body}'
+        result: function_response
+    - release_ingestion_lock:
+        call: http.post
+        args:
+          url: ${function_url}
+          auth:
+            type: OIDC
+          body:
+            actionType: release_ingestion_lock
+            workflowId: '${sys.get_env("GOOGLE_CLOUD_WORKFLOW_EXECUTION_ID")}'
+        result: function_response
+    - return_import_status:
+        return: '${import_status.body}'
+
+# This sub-workflow launches a Dataflow job and waits for it to complete.
+run_dataflow_job:
+  params: [import_list, project_id, job_name, template_gcs_path, location, spanner_database_id, wait_period]
+  steps:
+    - init:
+        assign:
+          - jobName: '${job_name + "-" + string(int(sys.now()))}'
+    - log_imports:
+        call: sys.log
+        args:
+          text: '${"Import list: " + import_list}'
+          severity: INFO 
+    - check_if_empty:
+        switch:
+          - condition: ${import_list == "[]"}
+            return: 'SUCCESS'
+    - launch_dataflow_job:
+        call: googleapis.dataflow.v1b3.projects.locations.flexTemplates.launch
+        args:
+          projectId: '${project_id}'
+          location: '${location}'
+          body:
+            launchParameter:
+              containerSpecGcsPath: '${template_gcs_path}'
+              jobName: '${jobName}'
+              parameters:
+                importList: '${import_list}'
+                spannerDatabaseId: '${spanner_database_id}'
+        result: launch_result
+    - wait_for_job_completion:
+        call: sys.sleep
+        args:
+          seconds: ${wait_period}
+        next: check_job_status
+    - check_job_status:
+        call: googleapis.dataflow.v1b3.projects.locations.jobs.get
+        args:
+          projectId: '${project_id}'
+          location: '${location}'
+          jobId: '${launch_result.job.id}'
+        result: job_status
+        next: check_if_done
+    - check_if_done:
+        switch:
+          - condition: ${job_status.currentState == "JOB_STATE_DONE"}
+            return: ${job_status.currentState}
+          - condition: ${job_status.currentState == "JOB_STATE_FAILED" or
+              job_status.currentState == "JOB_STATE_CANCELLED"}
+            next: fail_workflow
+        next: wait_for_job_completion
+    - fail_workflow:
+        raise:
+          message: '${"Dataflow job failed with status: " + job_status.currentState}'
+          code: 500


### PR DESCRIPTION
This PR adds a GCP workflow (spanner-ingestion-workflow) to perform incremental ingestion of spanner graph Data. It makes use of a cloud function (spanner-ingestion-helper) which handles state management in spanner tables. The core data ingestion to spanner graph is performed by a dataflow pipeline. 

The workflow performs the following high-level tasks:
 - Acquire ingestion lock
 - Get the list of pending imports
 - Run dataflow ingestion job
 - Update import status in spanner
 - Release ingestion lock
