### PR TITLE
fixed pvmap USMontlyReatilsales to not get malformed values in output

### DIFF
--- a/statvar_imports/us_census/us_monthly_retail_sales/monthly_retail_pvmap.csv
+++ b/statvar_imports/us_census/us_monthly_retail_sales/monthly_retail_pvmap.csv
@@ -126,3 +126,4 @@ TOTAL,observationDate,{Year},value,{Number},observationPeriod,P1Y,measurementQua
 2028,Year,2028,value,{Number},observationDate,{Year}-{Month},,,,,,,,,,
 2029,Year,2029,value,{Number},observationDate,{Year}-{Month},,,,,,,,,,
 2030,Year,2030,value,{Number},observationDate,{Year}-{Month},,,,,,,,,,
+"Prior to the benchmark report released",#ignore,footnote


### PR DESCRIPTION
Added a line to the pvmap file to prevent malformed values from being generated.
PR checklist - https://docs.google.com/spreadsheets/d/1BzweR9Sj58j0H2_BweGTmfE4Z1lrjPZL8u1FS0kzCeg/edit?gid=0#gid=0