### PR TITLE
fixing dependency for noaa

### DIFF
--- a/import-automation/executor/Dockerfile
+++ b/import-automation/executor/Dockerfile
@@ -37,7 +37,7 @@ xdg-utils \
 chromium \
 chromium-driver \
 p7zip-full \
-libeccodes
+libeccodes-dev
 # Install the Google Cloud CLI
 RUN apt-get update && \
     curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg && \

--- a/import-automation/executor/Dockerfile
+++ b/import-automation/executor/Dockerfile
@@ -37,7 +37,9 @@ xdg-utils \
 chromium \
 chromium-driver \
 p7zip-full \
-libeccodes-dev
+libeccodes-dev \
+libeccodes-tools \
+&& rm -rf /var/lib/apt/lists/*
 # Install the Google Cloud CLI
 RUN apt-get update && \
     curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg && \

--- a/scripts/noaa_gfs/manifest.json
+++ b/scripts/noaa_gfs/manifest.json
@@ -29,9 +29,9 @@
                 "disk": 4096
             },
             "config_override": {
-                "skip_gcs_upload": True,
-                "invoke_differ_tool": False,
-                "invoke_import_validation": False
+                "skip_gcs_upload": true,
+                "invoke_differ_tool": false,
+                "invoke_import_validation": false
             }
         }
     ]


### PR DESCRIPTION
After NOAA PR merged, libeccodes package was not getting installed in Dockerfile, this PR fixes the issue