### PR TITLE
disabling import tool for noaa gfs

### DIFF
--- a/scripts/noaa_gfs/manifest.json
+++ b/scripts/noaa_gfs/manifest.json
@@ -31,7 +31,8 @@
             "config_override": {
                 "skip_gcs_upload": true,
                 "invoke_differ_tool": false,
-                "invoke_import_validation": false
+                "invoke_import_validation": false,
+                "invoke_import_tool": false
             }
         }
     ]


### PR DESCRIPTION
This PR is to avoid the error in NOAA GFS automated runs:

"Error reading report.json /data/scripts/noaa_gfs/NOAA_GlobalForecastSystem/2026_04_16T23_06_53_177446_07_00/input0/genmcf/report.json file: 'NumRowSuccesses'"