### PR TITLE
skipped the redundant ids coming in output

### DIFF
--- a/scripts/eurostat/regional_statistics_by_nuts/birth_death_migration/import_data.py
+++ b/scripts/eurostat/regional_statistics_by_nuts/birth_death_migration/import_data.py
@@ -180,6 +180,18 @@ def clean_data(preprocessed_df, output_path):
     # number of columns should be 2 + 2X, we want the first 2 + X
     try:
         logging.info('Cleaning process start. ')
+
+        # Skip redundant IDs
+        ids_to_skip = ['HUX', 'HUXX', 'HUXXX', 'FRX', 'FRXX', 'FRXXX', 'EEXX', 'EEXXX']
+        mask_to_skip = preprocessed_df['geo'].isin(ids_to_skip)
+        if mask_to_skip.any():
+            skipped_data = preprocessed_df[mask_to_skip]
+            logging.info(
+                f"Skipping redundant IDs: {skipped_data['geo'].unique().tolist()}"
+            )
+
+        preprocessed_df = preprocessed_df[~mask_to_skip].copy()
+
         num_clean_columns = len(preprocessed_df.columns) // 2 + 1
         # drop unused columns
         clean_df = preprocessed_df.iloc[:, :num_clean_columns]

--- a/scripts/eurostat/regional_statistics_by_nuts/birth_death_migration/import_data.py
+++ b/scripts/eurostat/regional_statistics_by_nuts/birth_death_migration/import_data.py
@@ -182,7 +182,9 @@ def clean_data(preprocessed_df, output_path):
         logging.info('Cleaning process start. ')
 
         # Skip redundant IDs
-        ids_to_skip = ['HUX', 'HUXX', 'HUXXX', 'FRX', 'FRXX', 'FRXXX', 'EEXX', 'EEXXX']
+        ids_to_skip = [
+            'HUX', 'HUXX', 'HUXXX', 'FRX', 'FRXX', 'FRXXX', 'EEXX', 'EEXXX'
+        ]
         mask_to_skip = preprocessed_df['geo'].isin(ids_to_skip)
         if mask_to_skip.any():
             skipped_data = preprocessed_df[mask_to_skip]


### PR DESCRIPTION
In the Eurostat (and NUTS) classification system, HU is the code for Hungary.
The specific codes (HUX, HUXX ,EEXX ) follow a hierarchical structure used for statistical reporting. Here is the breakdown:

Country & Regional Codes
HU: The 2-letter ISO/Eurostat country code for Hungary.

HUX: This refers to "Extra-Regio" territory for Hungary at the NUTS 1 level.

HUXXX: This refers to "Extra-Regio" territory at the NUTS 3 level.

Hence the codes are undefined & also   the dcids for these mapping does not exist  in DC & throwing  missing reference ObservatioAbout error, so as a fix  we are skipping these.

After the code fix the differ is clean and has no deletions  - https://storage.mtls.cloud.google.com/datcom-prod-imports/statvar_imports/us_bls/bls_ces_state/BLS_CES_State/obs_diff_log.csv