### PR TITLE
[EPA_GHGRP] added logic to process only the files which are downloaded

### DIFF
--- a/import-automation/executor/requirements.txt
+++ b/import-automation/executor/requirements.txt
@@ -8,7 +8,6 @@ chromedriver_py
 croniter
 curl_cffi
 dataclasses
-datacommons
 datacommons_client
 db-dtypes
 duckdb

--- a/scripts/us_epa/ghgrp/download.py
+++ b/scripts/us_epa/ghgrp/download.py
@@ -144,6 +144,13 @@ class Downloader:
             logging.fatal(f"Failed to download or extract data for {year}: {e}")
             return False
 
+    def _get_summary_filename(self, year):
+        """Helper to construct the path for a year's Excel data file."""
+        return os.path.join(
+            self.save_path,
+            YEAR_DATA_FILENAME.format(year=year)
+        )
+
     def extract_all_years(self):
         """
         Extract and save data from downloaded Excel files for all years.
@@ -154,10 +161,7 @@ class Downloader:
         try:
             headers = {sheet: {} for sheet in SHEET_NAMES_TO_CSV_FILENAMES}
             for current_year in self.years:
-                # Construct the expected filename for the year
-                summary_filename = os.path.join(
-                    self.save_path,
-                    YEAR_DATA_FILENAME.format(year=current_year))
+                summary_filename = self._get_summary_filename(current_year)
                 
                 # Check if the file exists before processing
                 if not os.path.exists(summary_filename):
@@ -166,7 +170,7 @@ class Downloader:
 
                 logging.info(f'Extracting data for {current_year}')
                 self.current_year = current_year
-                self._extract_data(headers)
+                self._extract_data(summary_filename, headers)
             for sheet, csv_name in SHEET_NAMES_TO_CSV_FILENAMES.items():
                 headers_df = pd.DataFrame.from_dict(headers[sheet],
                                                     orient='index')
@@ -191,7 +195,12 @@ class Downloader:
         logging.info('Saving all ID crosswalks')
         try:
             crosswalks = []
-            for current_year in self.years:
+            for year in self.years:
+                summary_filename = self._get_summary_filename(year)
+                if not os.path.exists(summary_filename):
+                    continue
+                
+                self.current_year = year
                 crosswalks.append(self._gen_crosswalk())
             all_crosswalks_df = pd.concat(crosswalks, join='outer')
             all_crosswalks_df = all_crosswalks_df.sort_values(
@@ -217,17 +226,15 @@ class Downloader:
             year = self.current_year
         return os.path.join(self.save_path, f'{year}_{csv_filename}')
 
-    def _extract_data(self, headers):
+    def _extract_data(self, summary_filename, headers):
         """
         Extract data from Excel sheets and save them as CSV.
 
         Args:
+            summary_filename (str): The pre-verified path to the Excel file.
             headers (dict): Dictionary to store column headers per sheet and year.
         """
         try:
-            summary_filename = os.path.join(
-                self.save_path,
-                YEAR_DATA_FILENAME.format(year=self.current_year))
             xl = pd.ExcelFile(summary_filename, engine='openpyxl')
             logging.info(
                 f"Available sheets in {summary_filename}: {xl.sheet_names}")
@@ -279,10 +286,10 @@ class Downloader:
                                     engine='openpyxl')
         oris_df = oris_df.rename(columns={'GHGRP Facility ID': GHGRP_ID_COL})
         all_facilities_df = pd.DataFrame()
-        for sheet, csv_filename in SHEET_NAMES_TO_CSV_FILENAMES.items():
+        csv_filenames = list(SHEET_NAMES_TO_CSV_FILENAMES.values()) + ['direct_emitters.csv']
+        for csv_filename in csv_filenames:
             csv_path = self._csv_path(csv_filename)
             if not os.path.exists(csv_path):
-                logging.info(f"Skipping crosswalk for {csv_path} - file missing.")
                 continue
             df = pd.read_csv(csv_path,
                              usecols=[GHGRP_ID_COL, 'FRS Id'],

--- a/scripts/us_epa/ghgrp/download.py
+++ b/scripts/us_epa/ghgrp/download.py
@@ -146,10 +146,8 @@ class Downloader:
 
     def _get_summary_filename(self, year):
         """Helper to construct the path for a year's Excel data file."""
-        return os.path.join(
-            self.save_path,
-            YEAR_DATA_FILENAME.format(year=year)
-        )
+        return os.path.join(self.save_path,
+                            YEAR_DATA_FILENAME.format(year=year))
 
     def extract_all_years(self):
         """
@@ -162,10 +160,12 @@ class Downloader:
             headers = {sheet: {} for sheet in SHEET_NAMES_TO_CSV_FILENAMES}
             for current_year in self.years:
                 summary_filename = self._get_summary_filename(current_year)
-                
+
                 # Check if the file exists before processing
                 if not os.path.exists(summary_filename):
-                    logging.warning(f"Excel file for {current_year} not found at {summary_filename}. Skipping extraction.")
+                    logging.warning(
+                        f"Excel file for {current_year} not found at {summary_filename}. Skipping extraction."
+                    )
                     continue
 
                 logging.info(f'Extracting data for {current_year}')
@@ -199,10 +199,10 @@ class Downloader:
                 summary_filename = self._get_summary_filename(year)
                 if not os.path.exists(summary_filename):
                     continue
-                
+
                 self.current_year = year
                 crosswalks.append(self._gen_crosswalk())
-            
+
             if not crosswalks:
                 logging.warning("No crosswalk data found for any year.")
                 return pd.DataFrame()
@@ -211,7 +211,7 @@ class Downloader:
             if all_crosswalks_df.empty:
                 logging.warning("No crosswalk data found for any year.")
                 return all_crosswalks_df
-            
+
             all_crosswalks_df = all_crosswalks_df.sort_values(
                 by=[GHGRP_ID_COL, 'FRS Id', 'ORIS CODE'])
             all_crosswalks_df = all_crosswalks_df.drop_duplicates()
@@ -295,7 +295,8 @@ class Downloader:
                                     engine='openpyxl')
         oris_df = oris_df.rename(columns={'GHGRP Facility ID': GHGRP_ID_COL})
         all_facilities_df = pd.DataFrame()
-        csv_filenames = list(SHEET_NAMES_TO_CSV_FILENAMES.values()) + ['direct_emitters.csv']
+        csv_filenames = list(
+            SHEET_NAMES_TO_CSV_FILENAMES.values()) + ['direct_emitters.csv']
         for csv_filename in csv_filenames:
             csv_path = self._csv_path(csv_filename)
             if not os.path.exists(csv_path):
@@ -305,7 +306,7 @@ class Downloader:
                              dtype=str)
             all_facilities_df = pd.concat([all_facilities_df, df],
                                           ignore_index=True)
-        
+
         if all_facilities_df.empty:
             return pd.DataFrame()
 

--- a/scripts/us_epa/ghgrp/download.py
+++ b/scripts/us_epa/ghgrp/download.py
@@ -202,6 +202,11 @@ class Downloader:
                 
                 self.current_year = year
                 crosswalks.append(self._gen_crosswalk())
+            
+            if not crosswalks:
+                logging.warning("No crosswalk data found for any year.")
+                return pd.DataFrame()
+
             all_crosswalks_df = pd.concat(crosswalks, join='outer')
             all_crosswalks_df = all_crosswalks_df.sort_values(
                 by=[GHGRP_ID_COL, 'FRS Id', 'ORIS CODE'])
@@ -296,6 +301,10 @@ class Downloader:
                              dtype=str)
             all_facilities_df = pd.concat([all_facilities_df, df],
                                           ignore_index=True)
+        
+        if all_facilities_df.empty:
+            return pd.DataFrame()
+
         all_facilities_df = all_facilities_df.join(
             oris_df.set_index(GHGRP_ID_COL), on=GHGRP_ID_COL, how='left')
         return all_facilities_df

--- a/scripts/us_epa/ghgrp/download.py
+++ b/scripts/us_epa/ghgrp/download.py
@@ -154,6 +154,16 @@ class Downloader:
         try:
             headers = {sheet: {} for sheet in SHEET_NAMES_TO_CSV_FILENAMES}
             for current_year in self.years:
+                # Construct the expected filename for the year
+                summary_filename = os.path.join(
+                    self.save_path,
+                    YEAR_DATA_FILENAME.format(year=current_year))
+                
+                # Check if the file exists before processing
+                if not os.path.exists(summary_filename):
+                    logging.warning(f"Excel file for {current_year} not found at {summary_filename}. Skipping extraction.")
+                    continue
+
                 logging.info(f'Extracting data for {current_year}')
                 self.current_year = current_year
                 self._extract_data(headers)
@@ -272,6 +282,7 @@ class Downloader:
         for sheet, csv_filename in SHEET_NAMES_TO_CSV_FILENAMES.items():
             csv_path = self._csv_path(csv_filename)
             if not os.path.exists(csv_path):
+                logging.info(f"Skipping crosswalk for {csv_path} - file missing.")
                 continue
             df = pd.read_csv(csv_path,
                              usecols=[GHGRP_ID_COL, 'FRS Id'],

--- a/scripts/us_epa/ghgrp/download.py
+++ b/scripts/us_epa/ghgrp/download.py
@@ -208,6 +208,10 @@ class Downloader:
                 return pd.DataFrame()
 
             all_crosswalks_df = pd.concat(crosswalks, join='outer')
+            if all_crosswalks_df.empty:
+                logging.warning("No crosswalk data found for any year.")
+                return all_crosswalks_df
+            
             all_crosswalks_df = all_crosswalks_df.sort_values(
                 by=[GHGRP_ID_COL, 'FRS Id', 'ORIS CODE'])
             all_crosswalks_df = all_crosswalks_df.drop_duplicates()


### PR DESCRIPTION
This PR is to fix the current logic set up in the EPA_GHGRP import where the process.py tries to process files from all of the years even if the file is not downloaded, leading to no file found error:

message: "Process stderr:None: b"F0501 10:07:22.432482 140533133409152 download.py:242] Error occurred while processing the sheet names: [Errno 2] No such file or directory: 'tmp_data/ghgp_data_2024.xlsx'\n""
}

EPA source hasn't released data for 2024 yet due to which this issue got highlighted. This PR is to ensure that only those files are processed which are downloaded.