### PR TITLE
fixed db seed error

### DIFF
--- a/import-automation/workflow/ingestion-helper/spanner_client.py
+++ b/import-automation/workflow/ingestion-helper/spanner_client.py
@@ -565,11 +565,11 @@ class SpannerClient:
 
         def _seed(transaction: Transaction):
             candidates = {
-                "StatisticalVariable": ["StatisticalVariable", ["Class"], spanner.COMMIT_TIMESTAMP],
-                "StatVarGroup": ["StatVarGroup", ["Class"], spanner.COMMIT_TIMESTAMP],
-                "StatVarObservation": ["StatVarObservation", ["Class"], spanner.COMMIT_TIMESTAMP],
-                "Topic": ["Topic", ["Class"], spanner.COMMIT_TIMESTAMP],
-                "c/g/Root": ["c/g/Root", ["StatVarGroup"], spanner.COMMIT_TIMESTAMP],
+                "StatisticalVariable": ["StatisticalVariable", "StatisticalVariable", "StatisticalVariable", ["Class"], spanner.COMMIT_TIMESTAMP],
+                "StatVarGroup": ["StatVarGroup", "StatVarGroup", "StatVarGroup", ["Class"], spanner.COMMIT_TIMESTAMP],
+                "StatVarObservation": ["StatVarObservation", "StatVarObservation", "StatVarObservation", ["Class"], spanner.COMMIT_TIMESTAMP],
+                "Topic": ["Topic", "Topic", "Topic", ["Class"], spanner.COMMIT_TIMESTAMP],
+                "c/g/Root": ["c/g/Root", "c/g/Root", "c/g/Root", ["StatVarGroup"], spanner.COMMIT_TIMESTAMP],
             }
             subjects = list(candidates.keys())
             sql = "SELECT subject_id FROM Node WHERE subject_id IN UNNEST(@subjects)"
@@ -582,7 +582,7 @@ class SpannerClient:
             values = [candidates[subj] for subj in subjects if subj not in existing]
 
             if values:
-                columns = ["subject_id", "types", "last_update_timestamp"]
+                columns = ["subject_id", "name", "value", "types", "last_update_timestamp"]
                 transaction.insert(table="Node", columns=columns, values=values)
 
         try:

--- a/import-automation/workflow/ingestion-helper/spanner_client_test.py
+++ b/import-automation/workflow/ingestion-helper/spanner_client_test.py
@@ -246,10 +246,15 @@ class TestSpannerClient(unittest.TestCase):
         mock_transaction.insert.assert_called_once()
         args, kwargs = mock_transaction.insert.call_args
         self.assertEqual(kwargs['table'], 'Node')
+        self.assertEqual(kwargs['columns'], ["subject_id", "name", "value", "types", "last_update_timestamp"])
         self.assertEqual(len(kwargs['values']), 5)
         expected_subjects = ["StatisticalVariable", "StatVarGroup", "StatVarObservation", "Topic", "c/g/Root"]
         actual_subjects = [val[0] for val in kwargs['values']]
+        actual_names = [val[1] for val in kwargs['values']]
+        actual_values = [val[2] for val in kwargs['values']]
         self.assertEqual(actual_subjects, expected_subjects)
+        self.assertEqual(actual_names, expected_subjects)
+        self.assertEqual(actual_values, expected_subjects)
 
     @patch('google.cloud.spanner.Client')
     def test_seed_database_already_exists(self, mock_spanner_client):


### PR DESCRIPTION
This pull request updates the database seeding logic and its corresponding test to add two new fields, `name` and `value`, to the seeded `Node` table entries. The changes ensure that these fields are populated with appropriate values during the seeding process and that the tests verify their correctness.
