### PR TITLE
NOAA_GlobalForecastSystem_reorg_gcs_output_monthly

### DIFF
--- a/scripts/noaa_gfs/grib_statvar_processor.py
+++ b/scripts/noaa_gfs/grib_statvar_processor.py
@@ -646,10 +646,8 @@ def main(argv):
             month_str = date_str[4:6]
 
             gcs_filename = f"noaa_gfs_output_{date_str}_{cycle_str}_{f_hour}.csv"
-            gcs_full_path = (
-                f"{FLAGS.output_gcs_prefix.strip('/')}/"
-                f"{year_str}/{month_str}/{gcs_filename}"
-            )
+            gcs_full_path = (f"{FLAGS.output_gcs_prefix.strip('/')}/"
+                             f"{year_str}/{month_str}/{gcs_filename}")
 
             if grib_statvar_processor(input_path, gcs_full_path):
                 logging.info(

--- a/scripts/noaa_gfs/grib_statvar_processor.py
+++ b/scripts/noaa_gfs/grib_statvar_processor.py
@@ -641,8 +641,15 @@ def main(argv):
             cycle_str = cycle_match.group(1)
             f_hour = FLAGS.forecast_hour
 
+            # Extract year and month from the 8-digit date string (YYYYMMDD)
+            year_str = date_str[:4]
+            month_str = date_str[4:6]
+
             gcs_filename = f"noaa_gfs_output_{date_str}_{cycle_str}_{f_hour}.csv"
-            gcs_full_path = f"{FLAGS.output_gcs_prefix.strip('/')}/{gcs_filename}"
+            gcs_full_path = (
+                f"{FLAGS.output_gcs_prefix.strip('/')}/"
+                f"{year_str}/{month_str}/{gcs_filename}"
+            )
 
             if grib_statvar_processor(input_path, gcs_full_path):
                 logging.info(

--- a/scripts/noaa_gfs/manifest.json
+++ b/scripts/noaa_gfs/manifest.json
@@ -15,7 +15,7 @@
             "import_inputs": [
                 {
                     "template_mcf": "./noaa_gfs_output.tmcf",
-                    "cleaned_csv": "output/*/gfs.t*.csv"
+                    "cleaned_csv": "output/*/*/noaa_gfs_output_*.csv"
                 }
             ],
             "source_files": [


### PR DESCRIPTION
This PR is to reorganize the output path of NOAA processed files in GCS.

Earlier Path: gs://datcom-prod-imports/scripts/noaa_gfs/NOAA_GlobalForecastSystem/output/
Changed Path: gs://datcom-prod-imports/scripts/noaa_gfs/NOAA_GlobalForecastSystem/output/{YYYY}/{MM}/

The concern was raised by @hareesh-ms that the files will grow with time and thus should be organized month wise. Refer comment section in the document: https://docs.google.com/document/d/1jrazxQfcpB3u0YTzC8wBTG9a3KgB49KIpioCDb9OfVs/edit?resourcekey=0-kltavlIE_RN_BGurfvVrBQ&tab=t.0

Bug: https://buganizer.corp.google.com/issues/513413769