### PR TITLE
[DCP Ingestion] Replace c/g/Root by dc/g/Root in Seeding.

### DIFF
--- a/import-automation/workflow/ingestion-helper/spanner_client.py
+++ b/import-automation/workflow/ingestion-helper/spanner_client.py
@@ -569,7 +569,7 @@ class SpannerClient:
                 "StatVarGroup": ["StatVarGroup", "StatVarGroup", "StatVarGroup", ["Class"], spanner.COMMIT_TIMESTAMP],
                 "StatVarObservation": ["StatVarObservation", "StatVarObservation", "StatVarObservation", ["Class"], spanner.COMMIT_TIMESTAMP],
                 "Topic": ["Topic", "Topic", "Topic", ["Class"], spanner.COMMIT_TIMESTAMP],
-                "c/g/Root": ["c/g/Root", "c/g/Root", "c/g/Root", ["StatVarGroup"], spanner.COMMIT_TIMESTAMP],
+                "dc/g/Root": ["dc/g/Root", "Data Commons Variables", "Data Commons Variables", ["StatVarGroup"], spanner.COMMIT_TIMESTAMP],
             }
             subjects = list(candidates.keys())
             sql = "SELECT subject_id FROM Node WHERE subject_id IN UNNEST(@subjects)"

--- a/import-automation/workflow/ingestion-helper/spanner_client_test.py
+++ b/import-automation/workflow/ingestion-helper/spanner_client_test.py
@@ -248,13 +248,14 @@ class TestSpannerClient(unittest.TestCase):
         self.assertEqual(kwargs['table'], 'Node')
         self.assertEqual(kwargs['columns'], ["subject_id", "name", "value", "types", "last_update_timestamp"])
         self.assertEqual(len(kwargs['values']), 5)
-        expected_subjects = ["StatisticalVariable", "StatVarGroup", "StatVarObservation", "Topic", "c/g/Root"]
+        expected_subjects = ["StatisticalVariable", "StatVarGroup", "StatVarObservation", "Topic", "dc/g/Root"]
+        expected_names = ["StatisticalVariable", "StatVarGroup", "StatVarObservation", "Topic", "Data Commons Variables"]
         actual_subjects = [val[0] for val in kwargs['values']]
         actual_names = [val[1] for val in kwargs['values']]
         actual_values = [val[2] for val in kwargs['values']]
         self.assertEqual(actual_subjects, expected_subjects)
-        self.assertEqual(actual_names, expected_subjects)
-        self.assertEqual(actual_values, expected_subjects)
+        self.assertEqual(actual_names, expected_names)
+        self.assertEqual(actual_values, expected_names)
 
     @patch('google.cloud.spanner.Client')
     def test_seed_database_already_exists(self, mock_spanner_client):
@@ -265,7 +266,7 @@ class TestSpannerClient(unittest.TestCase):
         mock_instance.database.return_value = mock_db
 
         mock_transaction = MagicMock()
-        mock_transaction.execute_sql.return_value = [["StatisticalVariable"], ["StatVarGroup"], ["StatVarObservation"], ["Topic"], ["c/g/Root"]]
+        mock_transaction.execute_sql.return_value = [["StatisticalVariable"], ["StatVarGroup"], ["StatVarObservation"], ["Topic"], ["dc/g/Root"]]
         def run_in_transaction_side_effect(callback, *args, **kwargs):
             return callback(mock_transaction, *args, **kwargs)
         mock_db.run_in_transaction.side_effect = run_in_transaction_side_effect


### PR DESCRIPTION
The seeding needs dc/g/Root, not c/g/Root, which is automatically added when the CDC data job runs. 