### PR TITLE
[DCP - BQ Federation] Propagate location in to the BQ connection

### DIFF
--- a/import-automation/workflow/ingestion-helper/aggregation_utils.py
+++ b/import-automation/workflow/ingestion-helper/aggregation_utils.py
@@ -35,7 +35,7 @@ class BigQueryExecutor:
         self.database_id = database_id
         self.location = location
         try:
-            self.client = bigquery.Client(project=self.project_id)
+            self.client = bigquery.Client(project=self.project_id, location=self.location)
         except Exception as e:
             logging.warning(f"Failed to initialize BigQuery client: {e}")
             self.client = None

--- a/import-automation/workflow/ingestion-helper/aggregation_utils.py
+++ b/import-automation/workflow/ingestion-helper/aggregation_utils.py
@@ -27,11 +27,13 @@ class BigQueryExecutor:
                  connection_id: str,
                  project_id: str,
                  instance_id: str,
-                 database_id: str) -> None:
+                 database_id: str,
+                 location: Optional[str] = None) -> None:
         self.connection_id = connection_id
         self.project_id = project_id
         self.instance_id = instance_id
         self.database_id = database_id
+        self.location = location
         try:
             self.client = bigquery.Client(project=self.project_id)
         except Exception as e:
@@ -52,7 +54,7 @@ class BigQueryExecutor:
         logging.info(f"Executing query (first 100 chars): {query.strip()[:100]}...")
         
         try:
-            query_job = self.client.query(query, job_config=job_config)
+            query_job = self.client.query(query, job_config=job_config, location=self.location)
             result = query_job.result()
             duration = time.time() - start_time
             logging.info(f"Query completed in {duration:.2f}s. Job ID: {query_job.job_id}")
@@ -553,12 +555,14 @@ class AggregationUtils:
                  connection_id: str,
                  project_id: str,
                  instance_id: str,
-                 database_id: str) -> None:
+                 database_id: str,
+                 location: Optional[str] = None) -> None:
         self.executor = BigQueryExecutor(
             connection_id=connection_id,
             project_id=project_id,
             instance_id=instance_id,
-            database_id=database_id
+            database_id=database_id,
+            location=location
         )
         self.linked_edge_generator = LinkedEdgeGenerator(self.executor)
         self.provenance_summary_generator = ProvenanceSummaryGenerator(self.executor)

--- a/import-automation/workflow/ingestion-helper/aggregation_utils.py
+++ b/import-automation/workflow/ingestion-helper/aggregation_utils.py
@@ -54,7 +54,7 @@ class BigQueryExecutor:
         logging.info(f"Executing query (first 100 chars): {query.strip()[:100]}...")
         
         try:
-            query_job = self.client.query(query, job_config=job_config, location=self.location)
+            query_job = self.client.query(query, job_config=job_config)
             result = query_job.result()
             duration = time.time() - start_time
             logging.info(f"Query completed in {duration:.2f}s. Job ID: {query_job.job_id}")

--- a/import-automation/workflow/ingestion-helper/main.py
+++ b/import-automation/workflow/ingestion-helper/main.py
@@ -33,7 +33,7 @@ flags.DEFINE_string('spanner_connection_id',
                     'BigQuery Connection ID to access Cloud Spanner')
 flags.DEFINE_string('gcs_bucket_id', os.environ.get('GCS_BUCKET_ID'),
                     'GCS Bucket ID')
-flags.DEFINE_string('location', os.environ.get('LOCATION'), 'Location')
+flags.DEFINE_string('location', os.environ.get('LOCATION') or os.environ.get('REGION'), 'Location')
 flags.DEFINE_bool(
     'enable_embeddings',
     os.environ.get('ENABLE_EMBEDDINGS', 'false').lower() == 'true',
@@ -274,6 +274,7 @@ def ingestion_helper(request):
             project_id=FLAGS.spanner_project_id,
             instance_id=FLAGS.spanner_instance_id,
             database_id=FLAGS.spanner_graph_database_id,
+            location=FLAGS.location,
         )
         try:
             if aggregation.run_aggregation(import_list):


### PR DESCRIPTION
Allow using the env var REGION or LOCATION because base DC ingestion helper uses LOCATION, while DCP has been using the region env var everywhere. Would be great to align on one long term but this should be harmless.