### PR TITLE
fix: Register ValuesEntry helper in Observations PROTO BUNDLE

### DIFF
--- a/import-automation/workflow/ingestion-helper/schema.sql
+++ b/import-automation/workflow/ingestion-helper/schema.sql
@@ -13,7 +13,8 @@
 -- limitations under the License.
 
 CREATE PROTO BUNDLE (
-  `org.datacommons.Observations`
+  `org.datacommons.Observations`,
+  `org.datacommons.Observations.ValuesEntry`
 );
 
 CREATE TABLE Node (


### PR DESCRIPTION
This fixes the issue observed in http://b/511329206#comment9.

To enable native Spanner SQL engines and BigQuery Federation queries to parse map keys/values directly from the Observations PROTO column, the internal nested map-helper message `org.datacommons.Observations.ValuesEntry` must be explicitly registered inside the PROTO BUNDLE.

Without this, Spanner SQL queries fail when calling `UNNEST(observations.values)` with a "placeholder descriptor" error.