### PR TITLE
NASA_VIIRSActiveFireFirms|changed logic to stream subprocesses stdout and stderr

### DIFF
--- a/import-automation/executor/app/executor/import_executor.py
+++ b/import-automation/executor/app/executor/import_executor.py
@@ -481,8 +481,7 @@ class ImportExecutor:
                              "latency": timer.time(),
                              "input_index": input_index,
                              "import_input": import_prefix,
-                         },
-                         skip_stream_logging=True)
+                         })
             process.check_returncode()
             logging.info(
                 f'Generated resolved mcf for {import_prefix} in {output_path}.')
@@ -811,8 +810,7 @@ class ImportExecutor:
                                  "latency_secs": timer.time(),
                                  "script_index": script_index,
                                  "script_path": path,
-                             },
-                             skip_stream_logging=True)
+                             })
                 process.check_returncode()
 
         import_summary.import_stats['script_execution_time'] = start_timer.time(

--- a/import-automation/executor/app/executor/import_executor.py
+++ b/import-automation/executor/app/executor/import_executor.py
@@ -1405,7 +1405,7 @@ def _log_process(process: subprocess.CompletedProcess,
             payload_str = payload.decode('utf-8', errors='replace')
         else:
             payload_str = str(payload)
-        chunk_size = 100000
+        chunk_size = 50000
         total_len = len(payload_str)
 
         logging.info(f'--- Start of {label} (Total length: {total_len} chars) ---')

--- a/import-automation/executor/app/executor/import_executor.py
+++ b/import-automation/executor/app/executor/import_executor.py
@@ -1182,10 +1182,8 @@ def _run_with_timeout_async(args: List[str],
         # Log output continuously until the command completes.
         for line in process.stderr:
             stderr.append(line)
-            logging.info(f'Process stderr:{name}: {line}')
         for line in process.stdout:
             stdout.append(line)
-            logging.info(f'Process stdout:{name}: {line}')
 
         # Wait in case script has closed stderr/stdout early.
         process.wait()

--- a/import-automation/executor/app/executor/import_executor.py
+++ b/import-automation/executor/app/executor/import_executor.py
@@ -1418,6 +1418,9 @@ def _log_process(process: subprocess.CompletedProcess,
   Args:
       process: subprocess.CompletedProcess object whose arguments, return code,
         stdout, and stderr are to be logged.
+      import_name: Name of the import for labeling logs.
+      metrics: Dictionary to store execution metrics.
+      skip_stream_logging: Whether to skip chunked logging of stdout and stderr.
   """
     if metrics is None:
         metrics = {}

--- a/import-automation/executor/app/executor/import_executor.py
+++ b/import-automation/executor/app/executor/import_executor.py
@@ -77,7 +77,7 @@ AUTO_IMPORT_JOB_STAGE = "auto-import-job-stage"
 AUTO_IMPORT_JOB_STATUS = "auto-import-job-status"
 IMPORT_SUMMARY_FILE = "import_summary.json"
 STAGING_VERSION_FILE = "staging_version.txt"
-
+MAX_LOG_CHUNK_SIZE = 50000
 
 class ImportStatus(Enum):
     SUCCESS = 1
@@ -897,8 +897,7 @@ class ImportExecutor:
                          metrics={
                              "stage": ImportStage.INIT.name,
                              "latency_secs": timer.time(),
-                         },
-                         skip_stream_logging=False)
+                         })
             process.check_returncode()
 
             self._invoke_import_job(absolute_import_dir=absolute_import_dir,
@@ -1134,7 +1133,7 @@ def _stream_payload_in_chunks(label: str, payload) -> None:
     else:
         payload_str = str(payload)
 
-    chunk_size = 50000
+    chunk_size = MAX_LOG_CHUNK_SIZE
     total_len = len(payload_str)
 
     if total_len <= chunk_size:
@@ -1429,8 +1428,10 @@ def _log_process(process: subprocess.CompletedProcess,
     logging.info(message)
 
     if not skip_stream_logging:
-        _stream_payload_in_chunks(f'[{import_name}] Subprocess stdout', process.stdout)
-        _stream_payload_in_chunks(f'[{import_name}] Subprocess stderr', process.stderr)
+        _stream_payload_in_chunks(f'[{import_name}] Subprocess stdout',
+                                  process.stdout)
+        _stream_payload_in_chunks(f'[{import_name}] Subprocess stderr',
+                                  process.stderr)
 
     status = ImportStatus.FAILURE if process.returncode else ImportStatus.SUCCESS
     if import_name:

--- a/import-automation/executor/app/executor/import_executor.py
+++ b/import-automation/executor/app/executor/import_executor.py
@@ -1179,14 +1179,11 @@ def _run_with_timeout_async(args: List[str],
             env=env,
         )
 
-        # Log output continuously until the command completes.
-        for line in process.stderr:
-            stderr.append(line)
-        for line in process.stdout:
-            stdout.append(line)
-
-        # Wait in case script has closed stderr/stdout early.
-        process.wait()
+        out, err = process.communicate(timeout=timeout)
+        stdout.append(out)
+        stderr.append(err)
+        if process.returncode != 0:
+            raise RuntimeError(f"Process failed with exit code {process.returncode}")
         end_time = time.time()
 
         return_code = process.returncode

--- a/import-automation/executor/app/executor/import_executor.py
+++ b/import-automation/executor/app/executor/import_executor.py
@@ -1394,7 +1394,8 @@ def _clean_date(time: str) -> str:
 
 
 def _construct_process_message(message: str,
-                               process: subprocess.CompletedProcess) -> str:
+                               process: subprocess.CompletedProcess,
+                               include_streams: bool = False) -> str:
     """Constructs a log message describing the result of a subprocess.
 
   Args:
@@ -1408,12 +1409,11 @@ def _construct_process_message(message: str,
     message = (f'{message}\n'
                f'[Subprocess command]: {command}\n'
                f'[Subprocess return code]: {process.returncode}')
-    if hasattr(process, 'stdout') and process.stdout:
-        stdout_str = process.stdout.decode('utf-8', errors='replace') if isinstance(process.stdout, bytes) else str(process.stdout)
-        message += f'\n[Subprocess stdout]:\n{stdout_str}'
-    if hasattr(process, 'stderr') and process.stderr:
-        stderr_str = process.stderr.decode('utf-8', errors='replace') if isinstance(process.stderr, bytes) else str(process.stderr)
-        message += f'\n[Subprocess stderr]:\n{stderr_str}'
+    if include_streams:
+        if process.stdout:
+            message += f'\n[Subprocess stdout]:\n{process.stdout}'
+        if process.stderr:
+            message += f'\n[Subprocess stderr]:\n{process.stderr}'
 
     return message
 
@@ -1431,7 +1431,8 @@ def _log_process(process: subprocess.CompletedProcess,
     process_message = 'Subprocess succeeded'
     if process.returncode:
         process_message = 'Subprocess failed'
-    message = _construct_process_message(process_message, process)
+
+    message = _construct_process_message(process_message, process, include_streams=False)
     logging.info(message)
 
     if not skip_stream_logging:

--- a/import-automation/executor/app/executor/import_executor.py
+++ b/import-automation/executor/app/executor/import_executor.py
@@ -809,7 +809,8 @@ class ImportExecutor:
                                  "latency_secs": timer.time(),
                                  "script_index": script_index,
                                  "script_path": path,
-                             })
+                             },
+                             skip_stream_logging=True)
                 process.check_returncode()
 
         import_summary.import_stats['script_execution_time'] = start_timer.time(
@@ -1246,6 +1247,9 @@ def _run_with_timeout(args: List[str],
         logging.info(
             f'Completed command: {args}, retcode: {process.returncode}')
 
+        _stream_payload_in_chunks(f'[Command: {" ".join(args)}] stdout', process.stdout)
+        _stream_payload_in_chunks(f'[Command: {" ".join(args)}] stderr', process.stderr)
+
         return process
     except Exception as e:
         message = traceback.format_exc()
@@ -1410,7 +1414,8 @@ def _construct_process_message(message: str,
 
 def _log_process(process: subprocess.CompletedProcess,
                  import_name: str = '',
-                 metrics: dict = {}) -> None:
+                 metrics: dict = {},
+                 skip_stream_logging: bool = False) -> None:
     """Logs the result of a subprocess.
 
   Args:
@@ -1423,8 +1428,9 @@ def _log_process(process: subprocess.CompletedProcess,
     message = _construct_process_message(process_message, process)
     logging.info(message)
 
-    _stream_payload_in_chunks(f'[{import_name}] Subprocess stdout', process.stdout)
-    _stream_payload_in_chunks(f'[{import_name}] Subprocess stderr', process.stderr)
+    if not skip_stream_logging:
+        _stream_payload_in_chunks(f'[{import_name}] Subprocess stdout', process.stdout)
+        _stream_payload_in_chunks(f'[{import_name}] Subprocess stderr', process.stderr)
 
     status = ImportStatus.FAILURE if process.returncode else ImportStatus.SUCCESS
     if import_name:

--- a/import-automation/executor/app/executor/import_executor.py
+++ b/import-automation/executor/app/executor/import_executor.py
@@ -1420,6 +1420,8 @@ def _log_process(process: subprocess.CompletedProcess,
       process: subprocess.CompletedProcess object whose arguments, return code,
         stdout, and stderr are to be logged.
   """
+    if metrics is None:
+        metrics = {}
     process_message = 'Subprocess succeeded'
     if process.returncode:
         process_message = 'Subprocess failed'

--- a/import-automation/executor/app/executor/import_executor.py
+++ b/import-automation/executor/app/executor/import_executor.py
@@ -481,7 +481,8 @@ class ImportExecutor:
                              "latency": timer.time(),
                              "input_index": input_index,
                              "import_input": import_prefix,
-                         })
+                         },
+                         skip_stream_logging=True)
             process.check_returncode()
             logging.info(
                 f'Generated resolved mcf for {import_prefix} in {output_path}.')
@@ -810,7 +811,8 @@ class ImportExecutor:
                                  "latency_secs": timer.time(),
                                  "script_index": script_index,
                                  "script_path": path,
-                             })
+                             },
+                             skip_stream_logging=True)
                 process.check_returncode()
 
         import_summary.import_stats['script_execution_time'] = start_timer.time(
@@ -1179,11 +1181,16 @@ def _run_with_timeout_async(args: List[str],
             env=env,
         )
 
-        out, err = process.communicate(timeout=timeout)
-        stdout.append(out)
-        stderr.append(err)
-        if process.returncode != 0:
-            raise RuntimeError(f"Process failed with exit code {process.returncode}")
+        # Log output continuously until the command completes.
+        for line in process.stderr:
+            stderr.append(line)
+            logging.info(f'Process stderr:{name}: {line}')
+        for line in process.stdout:
+            stdout.append(line)
+            logging.info(f'Process stdout:{name}: {line}')
+
+        # Wait in case script has closed stderr/stdout early.
+        process.wait()
         end_time = time.time()
 
         return_code = process.returncode

--- a/import-automation/executor/app/executor/import_executor.py
+++ b/import-automation/executor/app/executor/import_executor.py
@@ -1378,10 +1378,6 @@ def _construct_process_message(message: str,
     message = (f'{message}\n'
                f'[Subprocess command]: {command}\n'
                f'[Subprocess return code]: {process.returncode}')
-    if process.stdout:
-        message += f'\n[Subprocess stdout]:\n{process.stdout}'
-    if process.stderr:
-        message += f'\n[Subprocess stderr]:\n{process.stderr}'
     return message
 
 
@@ -1399,6 +1395,27 @@ def _log_process(process: subprocess.CompletedProcess,
         process_message = 'Subprocess failed'
     message = _construct_process_message(process_message, process)
     logging.info(message)
+
+    # Helper function to split text and log in safe chunks
+    def _stream_payload_in_chunks(label: str, payload):
+        if not payload:
+            return
+
+        if isinstance(payload, bytes):
+            payload_str = payload.decode('utf-8', errors='replace')
+        else:
+            payload_str = str(payload)
+        chunk_size = 100000
+        total_len = len(payload_str)
+
+        logging.info(f'--- Start of {label} (Total length: {total_len} chars) ---')
+        for i in range(0, total_len, chunk_size):
+            chunk = payload_str[i:i + chunk_size]
+            logging.info(f'[{label} Part {i//chunk_size + 1}]:\n{chunk}')
+        logging.info(f'--- End of {label} ---')
+
+    _stream_payload_in_chunks('Subprocess stdout', process.stdout)
+    _stream_payload_in_chunks('Subprocess stderr', process.stderr)
 
     status = ImportStatus.FAILURE if process.returncode else ImportStatus.SUCCESS
     if import_name:

--- a/import-automation/executor/app/executor/import_executor.py
+++ b/import-automation/executor/app/executor/import_executor.py
@@ -79,6 +79,7 @@ IMPORT_SUMMARY_FILE = "import_summary.json"
 STAGING_VERSION_FILE = "staging_version.txt"
 MAX_LOG_CHUNK_SIZE = 50000
 
+
 class ImportStatus(Enum):
     SUCCESS = 1
     FAILURE = 2

--- a/import-automation/executor/app/executor/import_executor.py
+++ b/import-automation/executor/app/executor/import_executor.py
@@ -480,7 +480,8 @@ class ImportExecutor:
                              "latency": timer.time(),
                              "input_index": input_index,
                              "import_input": import_prefix,
-                         })
+                         },
+                         skip_stream_logging=True)
             process.check_returncode()
             logging.info(
                 f'Generated resolved mcf for {import_prefix} in {output_path}.')
@@ -896,7 +897,8 @@ class ImportExecutor:
                          metrics={
                              "stage": ImportStage.INIT.name,
                              "latency_secs": timer.time(),
-                         })
+                         },
+                         skip_stream_logging=False)
             process.check_returncode()
 
             self._invoke_import_job(absolute_import_dir=absolute_import_dir,
@@ -1247,9 +1249,6 @@ def _run_with_timeout(args: List[str],
         logging.info(
             f'Completed command: {args}, retcode: {process.returncode}')
 
-        _stream_payload_in_chunks(f'[Command: {" ".join(args)}] stdout', process.stdout)
-        _stream_payload_in_chunks(f'[Command: {" ".join(args)}] stderr', process.stderr)
-
         return process
     except Exception as e:
         message = traceback.format_exc()
@@ -1409,6 +1408,13 @@ def _construct_process_message(message: str,
     message = (f'{message}\n'
                f'[Subprocess command]: {command}\n'
                f'[Subprocess return code]: {process.returncode}')
+    if hasattr(process, 'stdout') and process.stdout:
+        stdout_str = process.stdout.decode('utf-8', errors='replace') if isinstance(process.stdout, bytes) else str(process.stdout)
+        message += f'\n[Subprocess stdout]:\n{stdout_str}'
+    if hasattr(process, 'stderr') and process.stderr:
+        stderr_str = process.stderr.decode('utf-8', errors='replace') if isinstance(process.stderr, bytes) else str(process.stderr)
+        message += f'\n[Subprocess stderr]:\n{stderr_str}'
+
     return message
 
 

--- a/import-automation/executor/app/executor/import_executor.py
+++ b/import-automation/executor/app/executor/import_executor.py
@@ -1243,11 +1243,8 @@ def _run_with_timeout(args: List[str],
                                  timeout=timeout,
                                  cwd=cwd,
                                  env=env)
-        process_message = 'Subprocess succeeded' if process.returncode == 0 else 'Subprocess failed'
         logging.info(
             f'Completed command: {args}, retcode: {process.returncode}')
-        _stream_payload_in_chunks(f'[Command: {" ".join(args)}] stdout', process.stdout)
-        _stream_payload_in_chunks(f'[Command: {" ".join(args)}] stderr', process.stderr)
 
         return process
     except Exception as e:

--- a/import-automation/executor/app/executor/import_executor.py
+++ b/import-automation/executor/app/executor/import_executor.py
@@ -1118,6 +1118,33 @@ def run_and_handle_exception(
         return ExecutionResult(ImportStatus.FAILURE, [], message)
 
 
+def _stream_payload_in_chunks(label: str, payload) -> None:
+    """Helper function to split text and log in safe chunks to avoid
+
+    "Log entry too large" (InvalidArgument) errors.
+    """
+    if not payload:
+        return
+
+    if isinstance(payload, bytes):
+        payload_str = payload.decode('utf-8', errors='replace')
+    else:
+        payload_str = str(payload)
+
+    chunk_size = 50000
+    total_len = len(payload_str)
+
+    if total_len <= chunk_size:
+        logging.info(f'{label}:\n{payload_str}')
+        return
+
+    logging.info(f'--- Start of {label} (Total length: {total_len} chars) ---')
+    for i in range(0, total_len, chunk_size):
+        chunk = payload_str[i:i + chunk_size]
+        logging.info(f'[{label} Part {i//chunk_size + 1}]:\n{chunk}')
+    logging.info(f'--- End of {label} ---')
+
+
 @log_function_call
 def _run_with_timeout_async(args: List[str],
                             timeout: float,
@@ -1216,9 +1243,12 @@ def _run_with_timeout(args: List[str],
                                  timeout=timeout,
                                  cwd=cwd,
                                  env=env)
+        process_message = 'Subprocess succeeded' if process.returncode == 0 else 'Subprocess failed'
         logging.info(
-            f'Completed command: {args}, retcode: {process.returncode}, stdout:'
-            f' {process.stdout}, stderr: {process.stderr}')
+            f'Completed command: {args}, retcode: {process.returncode}')
+        _stream_payload_in_chunks(f'[Command: {" ".join(args)}] stdout', process.stdout)
+        _stream_payload_in_chunks(f'[Command: {" ".join(args)}] stderr', process.stderr)
+
         return process
     except Exception as e:
         message = traceback.format_exc()
@@ -1395,24 +1425,6 @@ def _log_process(process: subprocess.CompletedProcess,
         process_message = 'Subprocess failed'
     message = _construct_process_message(process_message, process)
     logging.info(message)
-
-    # Helper function to split text and log in safe chunks
-    def _stream_payload_in_chunks(label: str, payload):
-        if not payload:
-            return
-
-        if isinstance(payload, bytes):
-            payload_str = payload.decode('utf-8', errors='replace')
-        else:
-            payload_str = str(payload)
-        chunk_size = 50000
-        total_len = len(payload_str)
-
-        logging.info(f'--- Start of {label} (Total length: {total_len} chars) ---')
-        for i in range(0, total_len, chunk_size):
-            chunk = payload_str[i:i + chunk_size]
-            logging.info(f'[{label} Part {i//chunk_size + 1}]:\n{chunk}')
-        logging.info(f'--- End of {label} ---')
 
     _stream_payload_in_chunks(f'[{import_name}] Subprocess stdout', process.stdout)
     _stream_payload_in_chunks(f'[{import_name}] Subprocess stderr', process.stderr)

--- a/import-automation/executor/app/executor/import_executor.py
+++ b/import-automation/executor/app/executor/import_executor.py
@@ -1414,8 +1414,8 @@ def _log_process(process: subprocess.CompletedProcess,
             logging.info(f'[{label} Part {i//chunk_size + 1}]:\n{chunk}')
         logging.info(f'--- End of {label} ---')
 
-    _stream_payload_in_chunks('Subprocess stdout', process.stdout)
-    _stream_payload_in_chunks('Subprocess stderr', process.stderr)
+    _stream_payload_in_chunks(f'[{import_name}] Subprocess stdout', process.stdout)
+    _stream_payload_in_chunks(f'[{import_name}] Subprocess stderr', process.stderr)
 
     status = ImportStatus.FAILURE if process.returncode else ImportStatus.SUCCESS
     if import_name:

--- a/import-automation/executor/app/executor/import_executor.py
+++ b/import-automation/executor/app/executor/import_executor.py
@@ -1408,6 +1408,10 @@ def _log_process(process: subprocess.CompletedProcess,
         chunk_size = 50000
         total_len = len(payload_str)
 
+        if total_len <= chunk_size:
+            logging.info(f'{label}:\n{payload_str}')
+            return
+
         logging.info(f'--- Start of {label} (Total length: {total_len} chars) ---')
         for i in range(0, total_len, chunk_size):
             chunk = payload_str[i:i + chunk_size]

--- a/import-automation/executor/app/executor/import_executor.py
+++ b/import-automation/executor/app/executor/import_executor.py
@@ -1394,8 +1394,7 @@ def _clean_date(time: str) -> str:
 
 
 def _construct_process_message(message: str,
-                               process: subprocess.CompletedProcess,
-                               include_streams: bool = False) -> str:
+                               process: subprocess.CompletedProcess) -> str:
     """Constructs a log message describing the result of a subprocess.
 
   Args:
@@ -1409,12 +1408,6 @@ def _construct_process_message(message: str,
     message = (f'{message}\n'
                f'[Subprocess command]: {command}\n'
                f'[Subprocess return code]: {process.returncode}')
-    if include_streams:
-        if process.stdout:
-            message += f'\n[Subprocess stdout]:\n{process.stdout}'
-        if process.stderr:
-            message += f'\n[Subprocess stderr]:\n{process.stderr}'
-
     return message
 
 
@@ -1432,7 +1425,7 @@ def _log_process(process: subprocess.CompletedProcess,
     if process.returncode:
         process_message = 'Subprocess failed'
 
-    message = _construct_process_message(process_message, process, include_streams=False)
+    message = _construct_process_message(process_message, process)
     logging.info(message)
 
     if not skip_stream_logging:

--- a/import-automation/executor/app/executor/import_executor.py
+++ b/import-automation/executor/app/executor/import_executor.py
@@ -1412,7 +1412,7 @@ def _construct_process_message(message: str,
 
 def _log_process(process: subprocess.CompletedProcess,
                  import_name: str = '',
-                 metrics: dict = {},
+                 metrics: dict = None,
                  skip_stream_logging: bool = False) -> None:
     """Logs the result of a subprocess.
 

--- a/import-automation/executor/test/import_executor_test.py
+++ b/import-automation/executor/test/import_executor_test.py
@@ -83,11 +83,7 @@ class ImportExecutorTest(unittest.TestCase):
         expected = (
             'message\n'
             '[Subprocess command]: printf "out" & >&2 printf "err" & exit 1\n'
-            '[Subprocess return code]: 1\n'
-            '[Subprocess stdout]:\n'
-            'out\n'
-            '[Subprocess stderr]:\n'
-            'err')
+            '[Subprocess return code]: 1')
         self.assertEqual(expected, message)
 
     def test_construct_process_message_no_output(self):

--- a/scripts/earthengine/process_events.py
+++ b/scripts/earthengine/process_events.py
@@ -1597,7 +1597,8 @@ class GeoEventsProcessor:
             if self._config.get('omit_events_subdir', False):
                 events_output_path = output_path
             else:
-                events_output_path = _get_output_subdir_path(output_path, 'events')
+                events_output_path = _get_output_subdir_path(
+                    output_path, 'events')
             output_files.append(
                 self.write_events_csv(output_path=events_output_path,
                                       output_ended_events=output_ended_events))

--- a/scripts/earthengine/process_events.py
+++ b/scripts/earthengine/process_events.py
@@ -1595,8 +1595,7 @@ class GeoEventsProcessor:
         if self._config.get('output_events', True):
             _set_counter_stage(self._counters, 'emit_events_csv_')
             output_files.append(
-                self.write_events_csv(output_path=_get_output_subdir_path(
-                    output_path, 'events'),
+                self.write_events_csv(output_path=output_path,
                                       output_ended_events=output_ended_events))
         if self._config.get('output_svobs', False):
             _set_counter_stage(self._counters, 'emit_events_svobs_')

--- a/scripts/earthengine/process_events.py
+++ b/scripts/earthengine/process_events.py
@@ -1594,8 +1594,12 @@ class GeoEventsProcessor:
             output_ended_events = True
         if self._config.get('output_events', True):
             _set_counter_stage(self._counters, 'emit_events_csv_')
+            if self._config.get('omit_events_subdir', False):
+                events_output_path = output_path
+            else:
+                events_output_path = _get_output_subdir_path(output_path, 'events')
             output_files.append(
-                self.write_events_csv(output_path=output_path,
+                self.write_events_csv(output_path=events_output_path,
                                       output_ended_events=output_ended_events))
         if self._config.get('output_svobs', False):
             _set_counter_stage(self._counters, 'emit_events_svobs_')

--- a/scripts/fires/firms/fire_events_pipeline_config.py
+++ b/scripts/fires/firms/fire_events_pipeline_config.py
@@ -88,7 +88,7 @@
             # Output events csv into a common folder with a year in filename,
             # as the import automation can copy all files in a single folder.
             "output_dir":
-                "gs://{gcs_bucket}/{gcs_folder}/{import_name}-{stage}-{year}-without-usa-",
+                "gs://{gcs_bucket}/{gcs_folder}/{stage}/{import_name}-{stage}-{year}-without-usa-",
             "event_type":
                 "FireEvent",
 

--- a/scripts/fires/firms/fire_events_pipeline_config.py
+++ b/scripts/fires/firms/fire_events_pipeline_config.py
@@ -173,6 +173,8 @@
             # Output settings.
             "output_svobs":
                 True,
+            "omit_events_subdir":
+                True,
             "output_delimiter":
                 ",",
             "output_affected_place_polygon":


### PR DESCRIPTION
This PR is to fix the below error that occurs in the cloud batch execution which can sometimes lead to pipeline halt even before the import can succeed (such as NASA_VIIRSActiveFireFirms)

textPayload: "Failed to flush logs after task task/nasa-viirsactivefi-bb54bcba-8c8d-42e80-group0-0/0/0: saw 1 errors; last: rpc error: code = InvalidArgument desc = Log entry with size 828.6K exceeds maximum size of 256.0K

The code change changes the logic to stream stdout and stderr in chunks instead of one go.

Changes:
- logs to be streamed instead of rendering to Cloud in one go (leading to failure and pipeline halt)
- test case fix to accommodate the logic change and thus successful build
- added config change to ensure correct folder structure "fires/firms/events/"