### PR TITLE
[DCP - Ingestion] Stop the scheduler calls for DCP

### DIFF
--- a/import-automation/workflow/ingestion-helper/main.py
+++ b/import-automation/workflow/ingestion-helper/main.py
@@ -162,6 +162,7 @@ def ingestion_helper(request):
         status = request_json['status']
         logging.info(f'Updating import {import_name} to status {status}')
         params = import_utils.get_import_params(request_json)
+        next_refresh = None
         if FLAGS.is_base_dc:
             next_refresh = import_utils.get_next_refresh(FLAGS.project_id, FLAGS.location, import_name)
 

--- a/import-automation/workflow/ingestion-helper/main.py
+++ b/import-automation/workflow/ingestion-helper/main.py
@@ -162,11 +162,12 @@ def ingestion_helper(request):
         status = request_json['status']
         logging.info(f'Updating import {import_name} to status {status}')
         params = import_utils.get_import_params(request_json)
-        next_refresh = import_utils.get_next_refresh(FLAGS.project_id,
-                                                     FLAGS.location,
-                                                     import_name)
+        if FLAGS.is_base_dc:
+            next_refresh = import_utils.get_next_refresh(FLAGS.project_id, FLAGS.location, import_name)
+
         if next_refresh:
             params['next_refresh'] = next_refresh
+
         if status == 'STAGING':
             version = os.path.basename(request_json.get('latestVersion', ''))
             if not version:


### PR DESCRIPTION
The ingestion helper was also configured to check the clodu scheduler configs for the current imoport's next refresh.

This is not yet a feature available for DCP, so I gated it on the is_base_dc env var.