### PR TITLE
This commit update the model endpoint, embedding index and timestamp field to use.

### DIFF
--- a/import-automation/workflow/ingestion-helper/embedding_schema.sql
+++ b/import-automation/workflow/ingestion-helper/embedding_schema.sql
@@ -24,8 +24,7 @@ CREATE VECTOR INDEX NodeEmbeddingIndex
 ON NodeEmbedding(embeddings)
 WHERE embeddings IS NOT NULL
 OPTIONS (
-  distance_type = 'COSINE',
-  flat_index = true
+  distance_type = 'COSINE'
 );
 
 CREATE MODEL NodeEmbeddingModel

--- a/import-automation/workflow/ingestion-helper/embedding_utils.py
+++ b/import-automation/workflow/ingestion-helper/embedding_utils.py
@@ -44,7 +44,7 @@ def get_latest_lock_timestamp(database):
     return None
 
 def get_updated_nodes(database, timestamp, node_types):
-    """Gets subject_ids and names from Node table where update_timestamp > timestamp.
+    """Gets subject_ids and names from Node table where last_update_timestamp > timestamp.
     Yields results to avoid loading all into memory.
     
     Args:
@@ -55,7 +55,7 @@ def get_updated_nodes(database, timestamp, node_types):
     Yields:
         Dictionaries containing subject_id and name.
     """
-    timestamp_condition = "update_timestamp > @timestamp" if timestamp else "TRUE"
+    timestamp_condition = "last_update_timestamp > @timestamp" if timestamp else "TRUE"
     
     updated_node_sql = f"""
         SELECT subject_id, name, types FROM Node 

--- a/import-automation/workflow/ingestion-helper/spanner_client.py
+++ b/import-automation/workflow/ingestion-helper/spanner_client.py
@@ -31,7 +31,7 @@ class SpannerClient:
     and getting/updating import statuses.
     """
     _LOCK_ID = "global_ingestion_lock"
-    _EMBEDDING_MODEL_PATH = "projects/{project}/locations/{location}/publishers/google/models/{model}"
+    _EMBEDDING_MODEL_PATH = "//aiplatform.googleapis.com/projects/{project}/locations/{location}/publishers/google/models/{model}"
 
     def __init__(self,
                  project_id: str,


### PR DESCRIPTION
The recent workflow finishes properly with above fixes and the NodeEmbedding table now generates the embeddings. We also confirm the last_update_timestamp get properly write from data ingestion

Workflow link: https://pantheon.corp.google.com/workflows/workflow/us-central1/xs-ebd-dc-ingestion-workflow/execution/09266b03-e1b0-430b-a7c5-ba0c8f271864/summary?e=13803378&mods=-monitoring_api_staging&project=datcom-website-dev