### PR TITLE
Update update_import_version.sh for new ingestion helper API

### DIFF
--- a/import-automation/executor/scripts/update_import_version.sh
+++ b/import-automation/executor/scripts/update_import_version.sh
@@ -34,4 +34,4 @@ COMMENT=$3
 curl -X POST "${FUNCTION_URL}/imports/version" \
   -H "Authorization: bearer $(gcloud auth print-identity-token)" \
   -H "Content-Type: application/json" \
-  -d "{\"importName\": \"${IMPORT_NAME}\", \"version\": \"${VERSION}\", \"override\": true, \"comment\": \"${COMMENT}\"}"
+  -d "{\"imports\": [\"${IMPORT_NAME}\"], \"version\": \"${VERSION}\", \"override\": true, \"comment\": \"${COMMENT}\"}"


### PR DESCRIPTION
Updates the update_import_version.sh script to use the new imports list field for the /imports/version endpoint, matching the changes in datacommonsorg/import#563.