### PR TITLE
fixed numpy issue

### DIFF
--- a/import-automation/executor/requirements.txt
+++ b/import-automation/executor/requirements.txt
@@ -34,7 +34,7 @@ gspread
 gunicorn
 legacy-cgi
 lxml
-numpy<2.0.0
+numpy<=2.0.0
 openpyxl
 pandas
 omegaconf

--- a/import-automation/executor/requirements.txt
+++ b/import-automation/executor/requirements.txt
@@ -34,7 +34,7 @@ gspread
 gunicorn
 legacy-cgi
 lxml
-numpy
+numpy<2.0.0
 openpyxl
 pandas
 omegaconf

--- a/scripts/us_census/geojsons_low_res/simplify.py
+++ b/scripts/us_census/geojsons_low_res/simplify.py
@@ -36,8 +36,8 @@ _orig_cross = np.cross
 def _robust_cross(a, b, *args, **kwargs):
     a_arr = np.asarray(a)
     b_arr = np.asarray(b)
-    if (a_arr.ndim > 0 and b_arr.ndim > 0 and a_arr.shape[-1] == 2 and
-            b_arr.shape[-1] == 2):
+    if (not args and not kwargs and a_arr.ndim > 0 and b_arr.ndim > 0 and
+            a_arr.shape[-1] == 2 and b_arr.shape[-1] == 2):
         return a_arr[..., 0] * b_arr[..., 1] - a_arr[..., 1] * b_arr[..., 0]
     return _orig_cross(a, b, *args, **kwargs)
 

--- a/scripts/us_census/geojsons_low_res/simplify.py
+++ b/scripts/us_census/geojsons_low_res/simplify.py
@@ -23,6 +23,11 @@
 """
 
 import numpy as np
+import rdp
+import geojson
+from absl import app
+from absl import flags
+from absl import logging
 
 # Monkey-patch np.cross to support 2D vectors under NumPy 2.x which removed it.
 _orig_cross = np.cross
@@ -38,12 +43,6 @@ def _robust_cross(a, b, *args, **kwargs):
 
 
 np.cross = _robust_cross
-
-import rdp
-import geojson
-from absl import app
-from absl import flags
-from absl import logging
 
 
 class GeojsonSimplifier:

--- a/scripts/us_census/geojsons_low_res/simplify.py
+++ b/scripts/us_census/geojsons_low_res/simplify.py
@@ -22,6 +22,13 @@
                         --out_path simplified-data/geoId-01-simple.geojson
 """
 
+import numpy as np
+
+# Monkey-patch np.cross to support 2D vectors under NumPy 2.x which removed it.
+_orig_cross = np.cross
+np.cross = lambda a, b, *args, **kwargs: (a[0] * b[1] - a[1] * b[0] if len(
+    a) == 2 and len(b) == 2 else _orig_cross(a, b, *args, **kwargs))
+
 import rdp
 import geojson
 from absl import app

--- a/scripts/us_census/geojsons_low_res/simplify.py
+++ b/scripts/us_census/geojsons_low_res/simplify.py
@@ -26,8 +26,18 @@ import numpy as np
 
 # Monkey-patch np.cross to support 2D vectors under NumPy 2.x which removed it.
 _orig_cross = np.cross
-np.cross = lambda a, b, *args, **kwargs: (a[0] * b[1] - a[1] * b[0] if len(
-    a) == 2 and len(b) == 2 else _orig_cross(a, b, *args, **kwargs))
+
+
+def _robust_cross(a, b, *args, **kwargs):
+    a_arr = np.asarray(a)
+    b_arr = np.asarray(b)
+    if (a_arr.ndim > 0 and b_arr.ndim > 0 and a_arr.shape[-1] == 2 and
+            b_arr.shape[-1] == 2):
+        return a_arr[..., 0] * b_arr[..., 1] - a_arr[..., 1] * b_arr[..., 0]
+    return _orig_cross(a, b, *args, **kwargs)
+
+
+np.cross = _robust_cross
 
 import rdp
 import geojson

--- a/scripts/us_census/geojsons_low_res/simplify.py
+++ b/scripts/us_census/geojsons_low_res/simplify.py
@@ -22,27 +22,11 @@
                         --out_path simplified-data/geoId-01-simple.geojson
 """
 
-import numpy as np
 import rdp
 import geojson
 from absl import app
 from absl import flags
 from absl import logging
-
-# Monkey-patch np.cross to support 2D vectors under NumPy 2.x which removed it.
-_orig_cross = np.cross
-
-
-def _robust_cross(a, b, *args, **kwargs):
-    a_arr = np.asarray(a)
-    b_arr = np.asarray(b)
-    if (not args and not kwargs and a_arr.ndim > 0 and b_arr.ndim > 0 and
-            a_arr.shape[-1] == 2 and b_arr.shape[-1] == 2):
-        return a_arr[..., 0] * b_arr[..., 1] - a_arr[..., 1] * b_arr[..., 0]
-    return _orig_cross(a, b, *args, **kwargs)
-
-
-np.cross = _robust_cross
 
 
 class GeojsonSimplifier:


### PR DESCRIPTION
 A recent update in NumPy (version 2.0+) broke how it handles 2D math operations. This broke an external library we use called rdp (which simplifies geographical boundaries), causing our automated tests to crash with a ValueError.

**FIX**
Pinned NumPy to <=2.0.0 in requirements.txt to maintain compatibility with the rdp library.
