### PR TITLE
Fix NumPy 2.0 compatibility in simplify.py using 3D padding

### DIFF
--- a/import-automation/executor/requirements.txt
+++ b/import-automation/executor/requirements.txt
@@ -34,7 +34,7 @@ gspread
 gunicorn
 legacy-cgi
 lxml
-numpy<=2.0.0
+numpy
 openpyxl
 pandas
 omegaconf

--- a/scripts/us_census/geojsons_low_res/simplify.py
+++ b/scripts/us_census/geojsons_low_res/simplify.py
@@ -85,7 +85,10 @@ class GeojsonSimplifier:
                 assert len(coords[i]) == 1
                 c = coords[i][0]
             original_size += len(c)
-            new_c = rdp.rdp(c, epsilon=epsilon)
+            # Pad to 3D to avoid NumPy 2.0+ deprecation/error on np.cross(2D) in rdp library
+            c_3d = [[p[0], p[1], 0.0] for p in c]
+            new_c_3d = rdp.rdp(c_3d, epsilon=epsilon)
+            new_c = [[p[0], p[1]] for p in new_c_3d]
             simplified_size += len(new_c)
             if len(new_c) >= 3:
                 # Simplify the polygon succeeded, not yielding a line


### PR DESCRIPTION
The `rdp` library calls `np.cross()` on 2D vectors, which fails with a `ValueError`  in NumPy 2.0+. PR #2078 attempted to fix this by pinning `numpy<=2.0.0`, but it caused pandas to segfault in [the CI](https://pantheon.corp.google.com/cloud-build/builds/487466a2-d4a5-4637-a106-3c6cb83e918c;step=3?e=13803378&mods=-monitoring_api_staging&project=datcom-ci) due to binary incompatibilities.

As a workaround, I padded 2D coordinates to 3D ([x, y, 0.0]) before passing them to `rdp.rdp` , and stripped them back to 2D afterwards. Since `np.cross` is supported for 3D vectors in NumPy 2.0+, this should fix the issue.

I ran the failing tests locally to confirm that they're passing now.