### PR TITLE
added goldens EurostatData_Demographic_Balance_Crude_Rates

### DIFF
--- a/scripts/eurostat/regional_statistics_by_nuts/birth_death_migration/golden_data/golden_summary_report.csv
+++ b/scripts/eurostat/regional_statistics_by_nuts/birth_death_migration/golden_data/golden_summary_report.csv
@@ -1,0 +1,8 @@
+"Units","StatVar","ScalingFactors","observationPeriods","NumPlaces","MeasurementMethods","MinDate"
+"[]","Count_Death_AsAFractionOfCount_Person","[]","[]","2122","[EurostatRegionalStatistics]","2000"
+"[]","GrowthRate_Count_Person","[]","[]","2122","[EurostatRegionalStatistics]","2000"
+"[]","Count_Death","[]","[]","2125","[EurostatRegionalStatistics]","2000"
+"[]","Count_Person","[]","[]","2125","[EurostatRegionalStatistics]","2000"
+"[]","Count_BirthEvent","[]","[]","2124","[EurostatRegionalStatistics]","2000"
+"[]","IncrementalCount_Person","[]","[]","2125","[EurostatRegionalStatistics]","2000"
+"[]","Count_BirthEvent_AsAFractionOfCount_Person","[]","[]","2121","[EurostatRegionalStatistics]","2000"

--- a/scripts/eurostat/regional_statistics_by_nuts/birth_death_migration/manifest.json
+++ b/scripts/eurostat/regional_statistics_by_nuts/birth_death_migration/manifest.json
@@ -20,7 +20,8 @@
                 "demo_r_gind3.tsv.gz",
                 "input_files/input_file.tsv"
             ],
-            "cron_schedule": "00 02 * * 2"
+            "cron_schedule": "00 02 * * 2",
+            "validation_config_file": "validation_config.json"
         }
     ]
 }

--- a/scripts/eurostat/regional_statistics_by_nuts/birth_death_migration/validation_config.json
+++ b/scripts/eurostat/regional_statistics_by_nuts/birth_death_migration/validation_config.json
@@ -1,0 +1,20 @@
+{
+    "schema_version": "1.0",
+    "rules": [
+        {
+            "rule_id": "check_deleted_records_percent",
+            "description": "Checks that the percentage of deleted points is within the threshold.",
+            "validator": "DELETED_RECORDS_PERCENT",
+            "params": {
+                "threshold": 0.5
+            }
+        },
+        {
+            "rule_id": "check_goldens_summary_report",
+            "validator": "GOLDENS_CHECK",
+            "params": {
+                "golden_files": "../../../../golden_data/golden_summary_report.csv"
+            }
+        }
+    ]
+}

--- a/scripts/eurostat/regional_statistics_by_nuts/birth_death_migration/validation_config.json
+++ b/scripts/eurostat/regional_statistics_by_nuts/birth_death_migration/validation_config.json
@@ -6,7 +6,7 @@
             "description": "Checks that the percentage of deleted points is within the threshold.",
             "validator": "DELETED_RECORDS_PERCENT",
             "params": {
-                "threshold": 0.5
+                "threshold": 0.1
             }
         },
         {


### PR DESCRIPTION
This import has recurring deletion failures less than 0.01%. To tackle these small deletions, the threshold has been increased, but we also added two new golden checks. These validation checks will verify that the data contains all sets in a golden set, these are defined within the validation_config.json file, which is situated in the same directory as manifest.json.  **The threshold has been raised to 0.05**, a value determined by historical and current deletion percentages, with a small buffer to account for these minor deletions.



PR checklist: https://docs.google.com/spreadsheets/d/1BzweR9Sj58j0H2_BweGTmfE4Z1lrjPZL8u1FS0kzCeg/edit?pli=1&gid=0#gid=0