### PR TITLE
Differ updates and fixes

### DIFF
--- a/import-automation/executor/app/executor/import_executor.py
+++ b/import-automation/executor/app/executor/import_executor.py
@@ -655,9 +655,9 @@ class ImportExecutor:
                     import_input=import_input,
                     absolute_import_dir=absolute_import_dir)
                 if differ_summary is not None:
-                    diff_found = (differ_summary.get('obs_diff_size', 1) != 0 or
-                                  differ_summary.get('schema_diff_size',
-                                                     1) != 0)
+                    diff_found = (
+                        differ_summary.get('obs_diff_count', 1) != 0 or
+                        differ_summary.get('schema_diff_count', 1) != 0)
                     differ_output = validation_output_path
             else:
                 logging.error('Skipping differ tool as per import config')

--- a/tools/import_differ/README.md
+++ b/tools/import_differ/README.md
@@ -60,3 +60,4 @@ Detailed diff output is written to MCF files in the output directory:
 - nodes-added.mcf: MCF nodes added in the current version
 - nodes-deleted.mcf: MCF nodes deleted in the current version
 - nodes-modified.mcf: MCF nodes modified in the current version
+- nodes-original.mcf: MCF nodes before modification (original values of modified nodes)

--- a/tools/import_differ/differ_utils.py
+++ b/tools/import_differ/differ_utils.py
@@ -9,55 +9,24 @@ import sys
 _SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 _DATA_DIR = os.path.dirname(os.path.dirname(_SCRIPT_DIR))
 sys.path.append(os.path.join(_DATA_DIR, 'util'))
+sys.path.append(os.path.join(_DATA_DIR, 'tools', 'statvar_importer'))
 
 from file_util import FileIO
 from file_util import file_get_matching
-
-_MCF_VALUE_SPLIT_RE = re.compile(r'\s*(?:"[^"\\]*(?:\\.[^"\\]*)*"|[^,]+)')
-
-
-def _parse_mcf_value(val: str):
-    val = val.strip()
-    if ',' not in val:
-        return val
-    parts = [p.strip() for p in _MCF_VALUE_SPLIT_RE.findall(val) if p.strip()]
-    return parts if len(parts) > 1 else val
+from mcf_file_util import load_mcf_nodes
 
 
-def load_mcf_file(file: str):
+def load_mcf_file(file: str) -> list:
     """ Reads an MCF text file and returns mcf nodes."""
-    with FileIO(file, 'r', encoding='utf-8') as mcf_file:
-        mcf_contents = mcf_file.read()
-    # nodes separated by a blank line
-    mcf_nodes_text = mcf_contents.split('\n\n')
-    # lines seprated as property: constraint
-    mcf_line = re.compile(r'^(\w+)\s*:\s*(.*)$')
-    mcf_nodes = []
-    for node in mcf_nodes_text:
-        current_mcf_node = {}
-        for line in node.split('\n'):
-            parsed_line = mcf_line.match(line)
-            if parsed_line is not None:
-                prop = parsed_line.group(1)
-                val = parsed_line.group(2).strip()
-                current_mcf_node[prop] = _parse_mcf_value(val)
-        if current_mcf_node:
-            mcf_nodes.append(current_mcf_node)
-
-    logging.info(f'Loaded {len(mcf_nodes)} nodes from file {file}')
-    return mcf_nodes
+    nodes_dict = load_mcf_nodes(file)
+    return list(nodes_dict.values())
 
 
-def load_mcf_files(path: str) -> pd.DataFrame:
+def load_mcf_files(path: str) -> list:
     """ Loads all sharded mcf files in the given directory and 
     returns a combined MCF node list."""
-    node_list = []
-    filenames = file_get_matching(path)
-    logging.info(f'Loading {len(filenames)} files from path {path}')
-    for filename in filenames:
-        nodes = load_mcf_file(filename)
-        node_list.extend(nodes)
-    return node_list
+    nodes_dict = load_mcf_nodes(path)
+    return list(nodes_dict.values())
 
 
 def load_csv_data(path: str, tmp_dir: str) -> pd.DataFrame:

--- a/tools/import_differ/differ_utils.py
+++ b/tools/import_differ/differ_utils.py
@@ -13,6 +13,16 @@ sys.path.append(os.path.join(_DATA_DIR, 'util'))
 from file_util import FileIO
 from file_util import file_get_matching
 
+_MCF_VALUE_SPLIT_RE = re.compile(r'\s*(?:"[^"\\]*(?:\\.[^"\\]*)*"|[^,]+)')
+
+
+def _parse_mcf_value(val: str):
+    val = val.strip()
+    if ',' not in val:
+        return val
+    parts = [p.strip() for p in _MCF_VALUE_SPLIT_RE.findall(val) if p.strip()]
+    return parts if len(parts) > 1 else val
+
 
 def load_mcf_file(file: str):
     """ Reads an MCF text file and returns mcf nodes."""
@@ -28,7 +38,9 @@ def load_mcf_file(file: str):
         for line in node.split('\n'):
             parsed_line = mcf_line.match(line)
             if parsed_line is not None:
-                current_mcf_node[parsed_line.group(1)] = parsed_line.group(2)
+                prop = parsed_line.group(1)
+                val = parsed_line.group(2).strip()
+                current_mcf_node[prop] = _parse_mcf_value(val)
         if current_mcf_node:
             mcf_nodes.append(current_mcf_node)
 

--- a/tools/import_differ/import_differ.py
+++ b/tools/import_differ/import_differ.py
@@ -31,9 +31,12 @@ from absl import logging
 from googleapiclient.discovery import build
 
 _SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+_DATA_DIR = os.path.dirname(os.path.dirname(_SCRIPT_DIR))
 sys.path.append(_SCRIPT_DIR)
+sys.path.append(os.path.join(_DATA_DIR, 'tools', 'statvar_importer'))
 
 import differ_utils
+from mcf_file_util import normalize_value
 
 _DATAFLOW_TEMPLATE_URL = 'gs://datcom-templates/templates/flex/differ.json'
 
@@ -78,13 +81,12 @@ flags.DEFINE_string('project_id', '', 'GCP project id for the dataflow job.')
 
 
 def val_str(value) -> str:
+    """Normalizes and stringifies a property value for diff comparison."""
     if isinstance(value, list):
-        return ", ".join([val_str(v) for v in value])
-    if (value and isinstance(value, str) and " " in value and
-            value[0].isalpha() and
-            not (value.startswith('"') and value.endswith('"'))):
-        return '"' + value + '"'
-    return str(value)
+        return ", ".join(sorted([val_str(v) for v in value]))
+    if isinstance(value, str):
+        return str(normalize_value(value))
+    return str(value) if value is not None else ''
 
 
 class ImportDiffer:

--- a/tools/import_differ/import_differ.py
+++ b/tools/import_differ/import_differ.py
@@ -79,8 +79,10 @@ flags.DEFINE_string('project_id', '', 'GCP project id for the dataflow job.')
 
 def val_str(value) -> str:
     if isinstance(value, list):
-        return ",".join([val_str(v) for v in value])
-    if value and isinstance(value, str) and " " in value and value[0].isalpha():
+        return ", ".join([val_str(v) for v in value])
+    if (value and isinstance(value, str) and " " in value and
+            value[0].isalpha() and
+            not (value.startswith('"') and value.endswith('"'))):
         return '"' + value + '"'
     return str(value)
 
@@ -111,6 +113,7 @@ class ImportDiffer:
   - nodes-added.mcf: MCF nodes added in the current version
   - nodes-deleted.mcf: MCF nodes deleted in the current version
   - nodes-modified.mcf: MCF nodes modified in the current version
+  - nodes-original.mcf: MCF nodes before modification (original values of modified nodes)
   - differ_summary.json: consolidated diff statistics 
 
   """
@@ -243,7 +246,8 @@ class ImportDiffer:
     def convert_diff_to_mcf_nodes(self,
                                   diff_df: pd.DataFrame,
                                   is_obs: bool,
-                                  diff_type: str = None) -> list:
+                                  diff_type: str = None,
+                                  suffix: str = None) -> list:
         """
         Converts the diff dataframe back to MCF format nodes.
         """
@@ -256,16 +260,17 @@ class ImportDiffer:
             if df_type.empty:
                 continue
 
+            # Determine which column suffix to use for values and node IDs
+            col_suffix = suffix if suffix else (
+                '_x' if d_type == Diff.DELETED.name else '_y')
+
             for _, row in df_type.iterrows():
                 node = {}
                 key_combined = str(row[Column.key_combined.name])
 
-                # Determine which column to use for values and node IDs
-                suffix = '_x' if d_type == Diff.DELETED.name else '_y'
-
                 # Helper to get value from row, handles cases with or without suffix
                 def get_val(base_name):
-                    col_name = base_name + suffix
+                    col_name = base_name + col_suffix
                     if col_name in row:
                         return str(row[col_name])
                     return str(row.get(base_name, ''))
@@ -435,15 +440,16 @@ class ImportDiffer:
                                              current_df_schema)
 
             logging.info('Writing diff to MCF files...')
-            for d_type, filename in [
-                (Diff.ADDED.name, 'nodes-added.mcf'),
-                (Diff.DELETED.name, 'nodes-deleted.mcf'),
-                (Diff.MODIFIED.name, 'nodes-modified.mcf'),
+            for d_type, filename, suffix in [
+                (Diff.ADDED.name, 'nodes-added.mcf', '_y'),
+                (Diff.DELETED.name, 'nodes-deleted.mcf', '_x'),
+                (Diff.MODIFIED.name, 'nodes-modified.mcf', '_y'),
+                (Diff.MODIFIED.name, 'nodes-original.mcf', '_x'),
             ]:
                 obs_nodes = self.convert_diff_to_mcf_nodes(
-                    obs_diff, True, d_type)
+                    obs_diff, True, d_type, suffix)
                 schema_nodes = self.convert_diff_to_mcf_nodes(
-                    schema_diff, False, d_type)
+                    schema_diff, False, d_type, suffix)
                 type_nodes = obs_nodes + schema_nodes
                 if type_nodes:
                     differ_utils.write_mcf_nodes(type_nodes, self.output_path,

--- a/tools/import_differ/import_differ_test.py
+++ b/tools/import_differ/import_differ_test.py
@@ -48,7 +48,7 @@ class TestImportDiffer(unittest.TestCase):
         # Check for expected files
         expected_files = [
             'nodes-added.mcf', 'nodes-deleted.mcf', 'nodes-modified.mcf',
-            'differ_summary.json'
+            'nodes-original.mcf', 'differ_summary.json'
         ]
 
         for f in expected_files:
@@ -58,7 +58,8 @@ class TestImportDiffer(unittest.TestCase):
 
         # Verify content of the combined MCF files
         for f_name in [
-                'nodes-added.mcf', 'nodes-deleted.mcf', 'nodes-modified.mcf'
+                'nodes-added.mcf', 'nodes-deleted.mcf', 'nodes-modified.mcf',
+                'nodes-original.mcf'
         ]:
             with open(os.path.join(output_location, f_name), 'r') as f:
                 content = f.read().strip()

--- a/tools/import_differ/test/results/nodes-added.mcf
+++ b/tools/import_differ/test/results/nodes-added.mcf
@@ -9,24 +9,24 @@ typeOf: StatVarObservation
 
 dcid: InterestRate_TreasuryNote_3Year
 maturity: [3 Year]
-measuredProperty: dcs:interestRate
+measuredProperty: dcid:interestRate
 name: "InterestRate_TreasuryNote_3Year"
-populationType: dcs:TreasuryNote
-statType: dcs:measuredValue
-typeOf: dcs:StatisticalVariable
+populationType: dcid:TreasuryNote
+statType: dcid:measuredValue
+typeOf: dcid:StatisticalVariable
 
 dcid: InterestRate_TreasuryNote_5Year
 maturity: [5 Year]
-measuredProperty: dcs:interestRate
+measuredProperty: dcid:interestRate
 name: "InterestRate_TreasuryNote_5Year"
-populationType: dcs:TreasuryNote
-statType: dcs:measuredValue
-typeOf: dcs:StatisticalVariable
+populationType: dcid:TreasuryNote
+statType: dcid:measuredValue
+typeOf: dcid:StatisticalVariable
 
 dcid: InterestRate_TreasuryNote_7Year
 maturity: [7 Year]
-measuredProperty: dcs:interestRate
+measuredProperty: dcid:interestRate
 name: "InterestRate_TreasuryNote_7Year"
-populationType: dcs:TreasuryNote
-statType: dcs:measuredValue
-typeOf: dcs:StatisticalVariable
+populationType: dcid:TreasuryNote
+statType: dcid:measuredValue
+typeOf: dcid:StatisticalVariable

--- a/tools/import_differ/test/results/nodes-deleted.mcf
+++ b/tools/import_differ/test/results/nodes-deleted.mcf
@@ -18,16 +18,16 @@ typeOf: StatVarObservation
 
 dcid: InterestRate_TreasuryBill_1Month
 maturity: [1 Month]
-measuredProperty: dcs:interestRate
+measuredProperty: dcid:interestRate
 name: "InterestRate_TreasuryBill_1Month"
-populationType: dcs:TreasuryBill
-statType: dcs:measuredValue
-typeOf: dcs:StatisticalVariable
+populationType: dcid:TreasuryBill
+statType: dcid:measuredValue
+typeOf: dcid:StatisticalVariable
 
 dcid: InterestRate_TreasuryBill_3Month
 maturity: [3 Month]
-measuredProperty: dcs:interestRate
+measuredProperty: dcid:interestRate
 name: "InterestRate_TreasuryBill_3Month"
-populationType: dcs:TreasuryBill
-statType: dcs:measuredValue
-typeOf: dcs:StatisticalVariable
+populationType: dcid:TreasuryBill
+statType: dcid:measuredValue
+typeOf: dcid:StatisticalVariable

--- a/tools/import_differ/test/results/nodes-modified.mcf
+++ b/tools/import_differ/test/results/nodes-modified.mcf
@@ -9,16 +9,16 @@ typeOf: StatVarObservation
 
 dcid: InterestRate_TreasuryBill_1Year
 maturity: [1 Year]
-measuredProperty: dcs:interestRate
+measuredProperty: dcid:interestRate
 name: "InterestRate_TreasuryBill_1Year"
-populationType: dcs:TreasuryBill
-statType: dcs:measuredValue
-typeOf: dcs:StatisticalVariable
+populationType: dcid:TreasuryBill
+statType: dcid:measuredValue
+typeOf: dcid:StatisticalVariable
 
 dcid: InterestRate_TreasuryNote_2Year
 maturity: [2 Year]
-measuredProperty: dcs:interestRate
+measuredProperty: dcid:interestRate
 name: "InterestRate_TreasuryNote_2Year"
-populationType: dcs:TreasuryNote
-statType: dcs:measuredValue
-typeOf: dcs:StatisticalVariable
+populationType: dcid:TreasuryNote
+statType: dcid:measuredValue
+typeOf: dcid:StatisticalVariable

--- a/tools/import_differ/test/results/nodes-original.mcf
+++ b/tools/import_differ/test/results/nodes-original.mcf
@@ -1,0 +1,24 @@
+Node: treasury_constant_maturity_rates/E10/115adaef-1547-4f5b-cabb-116d14c7a1ed
+variableMeasured: dcid:InterestRate_TreasuryBond_20Year
+observationAbout: dcid:country/USA
+observationDate: "2025-01-30"
+measurementMethod: dcid:ConstantMaturityRate
+unit: dcid:Percent
+value: 4.81
+typeOf: StatVarObservation
+
+dcid: InterestRate_TreasuryBill_1Year
+maturity: [1 Year]
+measuredProperty: dcs:interestRate
+name: "InterestRate_TreasuryBill_01Year"
+populationType: dcs:TreasuryBill
+statType: dcs:measuredValue
+typeOf: dcs:StatisticalVariable
+
+dcid: InterestRate_TreasuryNote_2Year
+maturity: [2 Year]
+measuredProperty: dcs:interestRate
+name: "InterestRate_TreasuryNote_02Year"
+populationType: dcs:TreasuryNote
+statType: dcs:measuredValue
+typeOf: dcs:StatisticalVariable

--- a/tools/import_differ/test/results/nodes-original.mcf
+++ b/tools/import_differ/test/results/nodes-original.mcf
@@ -9,16 +9,16 @@ typeOf: StatVarObservation
 
 dcid: InterestRate_TreasuryBill_1Year
 maturity: [1 Year]
-measuredProperty: dcs:interestRate
+measuredProperty: dcid:interestRate
 name: "InterestRate_TreasuryBill_01Year"
-populationType: dcs:TreasuryBill
-statType: dcs:measuredValue
-typeOf: dcs:StatisticalVariable
+populationType: dcid:TreasuryBill
+statType: dcid:measuredValue
+typeOf: dcid:StatisticalVariable
 
 dcid: InterestRate_TreasuryNote_2Year
 maturity: [2 Year]
-measuredProperty: dcs:interestRate
+measuredProperty: dcid:interestRate
 name: "InterestRate_TreasuryNote_02Year"
-populationType: dcs:TreasuryNote
-statType: dcs:measuredValue
-typeOf: dcs:StatisticalVariable
+populationType: dcid:TreasuryNote
+statType: dcid:measuredValue
+typeOf: dcid:StatisticalVariable


### PR DESCRIPTION
This PR makes the following changes to the differ:
a) Added a new output file containing the original values of modified nodes (for debugging)
b) Updated MCF parsing logic to handle quoted strings cleanly
c) Fixes the differ counter names to check for SKIP state in the executor
