### PR TITLE
Fix concurrent subprocess output handling in import executor

### DIFF
--- a/import-automation/executor/app/executor/import_executor.py
+++ b/import-automation/executor/app/executor/import_executor.py
@@ -26,6 +26,7 @@ import shlex
 import sys
 import subprocess
 import tempfile
+import threading
 import time
 import traceback
 from typing import Callable, Dict, Iterable, List, Optional, Tuple
@@ -1182,15 +1183,27 @@ def _run_with_timeout_async(args: List[str],
         )
 
         # Log output continuously until the command completes.
-        for line in process.stderr:
-            stderr.append(line)
-            logging.info(f'Process stderr:{name}: {line}')
-        for line in process.stdout:
-            stdout.append(line)
-            logging.info(f'Process stdout:{name}: {line}')
+        def drain_stream(stream, output, stream_name):
+            for line in stream:
+                output.append(line)
+                logging.info(f'Process {stream_name}:{name}: {line}')
+
+        stdout_thread = threading.Thread(
+            target=drain_stream,
+            args=(process.stdout, stdout, 'stdout'),
+        )
+        stderr_thread = threading.Thread(
+            target=drain_stream,
+            args=(process.stderr, stderr, 'stderr'),
+        )
+
+        stdout_thread.start()
+        stderr_thread.start()
 
         # Wait in case script has closed stderr/stdout early.
         process.wait()
+        stdout_thread.join()
+        stderr_thread.join()
         end_time = time.time()
 
         return_code = process.returncode

--- a/import-automation/executor/test/import_executor_test.py
+++ b/import-automation/executor/test/import_executor_test.py
@@ -19,6 +19,7 @@ import unittest
 from unittest import mock
 import subprocess
 import tempfile
+import threading
 
 from app.executor import import_executor
 from app.executor.import_executor import ImportStatus
@@ -43,6 +44,27 @@ class ImportExecutorTest(unittest.TestCase):
         self.assertRaises(subprocess.TimeoutExpired,
                           import_executor._run_with_timeout, ['sleep', '5'],
                           0.1)
+
+    def test_run_with_timeout_async_drains_streams_concurrently(self):
+        barrier = threading.Barrier(2)
+
+        def stream(line):
+            barrier.wait(timeout=5)
+            yield line
+
+        process = mock.Mock(returncode=0)
+        process.stdout = stream(b'stdout\n')
+        process.stderr = stream(b'stderr\n')
+
+        with mock.patch.object(import_executor.subprocess,
+                               'Popen',
+                               return_value=process):
+            result = import_executor._run_with_timeout_async(['command'], 1)
+
+        self.assertEqual(0, result.returncode)
+        self.assertEqual(b'stdout\n', result.stdout)
+        self.assertEqual(b'stderr\n', result.stderr)
+        process.wait.assert_called_once_with()
 
     def test_create_venv(self):
         with tempfile.NamedTemporaryFile(mode='w+') as requirements:


### PR DESCRIPTION
## Summary

- Drain subprocess stdout and stderr concurrently using separate reader threads.
- Preserve differentiated live logging and captured stdout/stderr.
- Join both readers after process completion to capture trailing output.
- Add a hermetic regression test for concurrent stream draining.

## Why

The executor previously drained stderr completely before reading stdout. If a subprocess filled the stdout pipe while keeping stderr open, the subprocess blocked waiting for stdout space while the executor waited for stderr EOF, causing a deadlock.

Reading both pipes concurrently prevents either pipe from blocking the subprocess.

Timeout and process-termination behavior are unchanged.

## Testing

- Focused concurrency regression test passed.
- `git diff --check` passed.