### PR TITLE
Handle timeout gracefully for skip-listed URLs in USCensusPEP_Sex

### DIFF
--- a/scripts/us_census/pep/us_pep_sex/process.py
+++ b/scripts/us_census/pep/us_pep_sex/process.py
@@ -1143,7 +1143,7 @@ def is_valid_url(url):
                 return False
         return True
     except Exception as e:
-        logging.fatal(f"Error checking URL: {url} - {e}")
+        logging.warning(f"Error checking URL: {url} - {e}")
         return False
 
 


### PR DESCRIPTION
### Description
This PR resolves a vulnerability in the `USCensusPEP_Sex` import pipeline where a transient network timeout during URL verification of a skip-listed file caused the entire job to crash.

*   **Fix**: Modified `is_valid_url` in `process.py` to log a warning instead of a fatal error on connection/timeout exceptions. This allows the script to skip the URL and proceed, which is the intended behavior for files already marked for skipping.

### Verification
*   Ran local tests: `PYTHON_REQUIREMENTS_INSTALLED=true ./run_tests.sh -p scripts/us_census/pep/us_pep_sex/` (Passed).
*   Verified clean format (`./run_tests.sh -f`) and lint (`./run_tests.sh -l`).

