### PR TITLE
Add timeout to URL availability checks in USCensusPEP_Sex

### DIFF
--- a/scripts/us_census/pep/us_pep_sex/process.py
+++ b/scripts/us_census/pep/us_pep_sex/process.py
@@ -1157,6 +1157,10 @@ def add_future_year_urls():
     global _FILES_TO_DOWNLOAD
     # Initialize the list to store files to download
     _FILES_TO_DOWNLOAD = []
+
+    # Use a requests session for connection pooling to improve efficiency
+    # when making hundreds of HEAD requests.
+    session = requests.Session()
     with open(os.path.join(_MODULE_DIR, 'input_url.json'), 'r') as inpit_file:
         _FILES_TO_DOWNLOAD = json.load(inpit_file)
 
@@ -1199,9 +1203,9 @@ def add_future_year_urls():
         gatekeeper_url = urls_to_scan[0].format(YEAR=future_year)
         try:
             # Use a short 5-second timeout for the check
-            response = requests.head(gatekeeper_url,
-                                     allow_redirects=True,
-                                     timeout=5)
+            response = session.head(gatekeeper_url,
+                                    allow_redirects=True,
+                                    timeout=5)
             if response.status_code != 200:
                 logging.info(
                     f"Skipping year {future_year}: National file not found (status code: {response.status_code})."
@@ -1224,9 +1228,9 @@ def add_future_year_urls():
 
                     try:
                         # HEAD calls only fetch headers and should complete quickly.
-                        check_url = requests.head(url_to_check,
-                                                  allow_redirects=True,
-                                                  timeout=5)
+                        check_url = session.head(url_to_check,
+                                                 allow_redirects=True,
+                                                 timeout=5)
                         if check_url.status_code == 200:
                             _FILES_TO_DOWNLOAD.append(
                                 {"download_path": url_to_check})
@@ -1244,9 +1248,9 @@ def add_future_year_urls():
 
                 try:
                     # HEAD calls only fetch headers and should complete quickly.
-                    check_url = requests.head(url_to_check,
-                                              allow_redirects=True,
-                                              timeout=5)
+                    check_url = session.head(url_to_check,
+                                             allow_redirects=True,
+                                             timeout=5)
                     if check_url.status_code == 200:
                         _FILES_TO_DOWNLOAD.append(
                             {"download_path": url_to_check})

--- a/scripts/us_census/pep/us_pep_sex/process.py
+++ b/scripts/us_census/pep/us_pep_sex/process.py
@@ -1223,8 +1223,10 @@ def add_future_year_urls():
                     logging.info(f"checking url: {url_to_check}")
 
                     try:
+                        # HEAD calls only fetch headers and should complete quickly.
                         check_url = requests.head(url_to_check,
-                                                  allow_redirects=True)
+                                                  allow_redirects=True,
+                                                  timeout=5)
                         if check_url.status_code == 200:
                             _FILES_TO_DOWNLOAD.append(
                                 {"download_path": url_to_check})
@@ -1241,8 +1243,10 @@ def add_future_year_urls():
                     continue  # Skip this URL if it's already processed
 
                 try:
+                    # HEAD calls only fetch headers and should complete quickly.
                     check_url = requests.head(url_to_check,
-                                              allow_redirects=True)
+                                              allow_redirects=True,
+                                              timeout=5)
                     if check_url.status_code == 200:
                         _FILES_TO_DOWNLOAD.append(
                             {"download_path": url_to_check})


### PR DESCRIPTION
### Description
This PR resolves a hang issue in the `USCensusPEP_Sex` import pipeline where the script would wait indefinitely (up to the server's default 2-minute timeout) for each non-responsive URL check during the candidate URL scanning phase.

*   **Fix**: Added `timeout=5` to `requests.head` calls in `add_future_year_urls` (lines 1226 and 1244) to ensure the script fails fast and skips slow/throttled URLs.

### Verification
*   Ran local tests: `PYTHON_REQUIREMENTS_INSTALLED=true ./run_tests.sh -p scripts/us_census/pep/us_pep_sex/` (Passed).
*   Verified clean format (`./run_tests.sh -f`) and lint (`./run_tests.sh -l`).
