### PR TITLE
[UAE_Population] Fix UAE population import download URL

### DIFF
--- a/statvar_imports/uae_bayanat/uae_population/README.md
+++ b/statvar_imports/uae_bayanat/uae_population/README.md
@@ -1,6 +1,6 @@
 # UAE_Population
 
-- source: https://admin.bayanat.ae/Dataset/DownloadDatasetResource?fileId=26585eaf-9a9c-486d-b773-fc51ef0204c9&resourceID=11243, 
+- source: https://bayanat.ae/api/DatasetResources/DownloadSingle?resourceID=FT1CGOdcLYt6KdUJnFHWwOdTWpeao-LX539QkMLeAKA&fileName=UAE%20Population%20By%20Emirates%20Nationality%20and%20gender,
 
 - how to download data: Download script (uae_download.py).
     To download the data, you'll need to use the provided download script, download_script/uae_download.py. This script will download a file to be processed. The script also requires a configuration file (config.ini) to function correctly.
@@ -20,8 +20,6 @@
 #### How to run:
 
 `python3 stat_var_processor.py --existing_statvar_mcf=gs://unresolved_mcf/scripts/statvar/stat_vars.mcf --input_data=../../statvar_imports/uae_bayanat/uae_population/input/uae_populationbyemiratesnationalityandgender.xlsx --pv_map=../../statvar_imports/uae_bayanat/uae_population/uae_population_pvmap.csv --places_resolved_csv=../../statvar_imports/uae_bayanat/uae_population/uae_population_places_resolved_csv.csv --config_file=../../statvar_imports/uae_bayanat/uae_population/uae_population_metadata.csv --output_path=../../statvar_imports/uae_bayanat/uae_population/output/uae_population_output`
-
-
 
 
 

--- a/statvar_imports/uae_bayanat/uae_population/README.md
+++ b/statvar_imports/uae_bayanat/uae_population/README.md
@@ -1,6 +1,6 @@
 # UAE_Population
 
-- source: https://bayanat.ae/api/DatasetResources/DownloadSingle?resourceID=FT1CGOdcLYt6KdUJnFHWwOdTWpeao-LX539QkMLeAKA&fileName=UAE%20Population%20By%20Emirates%20Nationality%20and%20gender,
+- source: https://bayanat.ae/api/DatasetResources/DownloadSingle?resourceID=FT1CGOdcLYt6KdUJnFHWwOdTWpeao-LX539QkMLeAKA&fileName=UAE%20Population%20By%20Emirates%20Nationality%20and%20gender
 
 - how to download data: Download script (uae_download.py).
     To download the data, you'll need to use the provided download script, download_script/uae_download.py. This script will download a file to be processed. The script also requires a configuration file (config.ini) to function correctly.

--- a/statvar_imports/uae_bayanat/uae_population/config.ini
+++ b/statvar_imports/uae_bayanat/uae_population/config.ini
@@ -1,2 +1,2 @@
 [DEFAULT]
-UAE_Population_URL = https://admin.bayanat.ae/Dataset/DownloadDatasetResource?fileId=26585eaf-9a9c-486d-b773-fc51ef0204c9&resourceID=11243
+UAE_Population_URL = https://bayanat.ae/api/DatasetResources/DownloadSingle?resourceID=FT1CGOdcLYt6KdUJnFHWwOdTWpeao-LX539QkMLeAKA&fileName=UAE%%20Population%%20By%%20Emirates%%20Nationality%%20and%%20gender

--- a/statvar_imports/uae_bayanat/uae_population/manifest.json
+++ b/statvar_imports/uae_bayanat/uae_population/manifest.json
@@ -5,7 +5,7 @@
             "curator_emails": [
                 "support@datacommons.org"
             ],
-            "provenance_url": "https://admin.bayanat.ae/Dataset/DownloadDatasetResource?fileId=26585eaf-9a9c-486d-b773-fc51ef0204c9&resourceID=11243",
+            "provenance_url": "https://bayanat.ae/api/DatasetResources/DownloadSingle?resourceID=FT1CGOdcLYt6KdUJnFHWwOdTWpeao-LX539QkMLeAKA&fileName=UAE%20Population%20By%20Emirates%20Nationality%20and%20gender",
             "provenance_description": "UAE_Population statical data",
             "scripts": [
                 "uae_download.py",

--- a/statvar_imports/uae_bayanat/uae_population/uae_population_metadata.csv
+++ b/statvar_imports/uae_bayanat/uae_population/uae_population_metadata.csv
@@ -1,5 +1,5 @@
 parameter,value
-url,https://admin.bayanat.ae/Dataset/DownloadDatasetResource?fileId=26585eaf-9a9c-486d-b773-fc51ef0204c9&resourceID=11243
+url,https://bayanat.ae/api/DatasetResources/DownloadSingle?resourceID=FT1CGOdcLYt6KdUJnFHWwOdTWpeao-LX539QkMLeAKA&fileName=UAE%20Population%20By%20Emirates%20Nationality%20and%20gender
 description,UAEPopulationByEmiratesNationalityandgender
 #place_type,Country
 #places_within,country/ARE


### PR DESCRIPTION
Updates the UAE population importer to use Bayanat’s current HTTPS download endpoint.

The downloaded workbook was compared with the committed import fixture and is identical in headers, dimensions, and cell values. Provenance references in the manifest, metadata, and README now match the downloader URL.