### PR TITLE
Fix TMCF entity definition in CDC_OzoneCounty

### DIFF
--- a/scripts/us_cdc/environmental_health_toxicology/OzoneCountyPollution.tmcf
+++ b/scripts/us_cdc/environmental_health_toxicology/OzoneCountyPollution.tmcf
@@ -1,8 +1,4 @@
 Node: E:OzoneCountyPollution->E1
-typeOf: dcs:County
-dcid: C:OzoneCountyPollution->dcid
-
-Node: E:OzoneCountyPollution->E1
 observationAbout: C:OzoneCountyPollution->dcid
 typeOf: dcs:StatVarObservation
 observationDate: C:OzoneCountyPollution->date


### PR DESCRIPTION
Remove duplicate County entity definition on E1 in OzoneCountyPollution.tmcf.
This ensures Mean_Concentration_AirPollutant_Ozone generates discrete daily StatVarObservation records instead of merged multi-date lists, resolving differ validation failures and enabling downstream time-series ingestion.