### PR TITLE
Add instruction adherence and deep-review rigor to import review skills

### DIFF
--- a/agents/docs/skill-authoring.md
+++ b/agents/docs/skill-authoring.md
@@ -58,6 +58,14 @@ when they differ.
   example, "Why did this import fail?" should route to troubleshooting.
 - Focus on repository knowledge, procedures, and non-obvious edge cases. Skip
   background the agent already handles well.
+- Use bullet points for distinct constraints and directives: LLMs treat bullet
+  items as actionable checklists, whereas rules buried in paragraphs are easily
+  overlooked.
+- Keep instructions punchy, imperative, and scannable: Short, direct commands
+  give rules maximum instruction-following weight.
+- Explicitly ban unverified assumptions: Instruct the agent to trace code paths,
+  verify edge cases, and ground findings in actual tool/code output rather than
+  guessing.
 - State the situation and action together. For example, "If no Batch job ID
   exists, inspect Scheduler."
 - Use short sentences and consistent terms.

--- a/agents/prompts/dc-import-code-review-starter.md
+++ b/agents/prompts/dc-import-code-review-starter.md
@@ -5,6 +5,10 @@ Use the `dc-import-code-review` skill to review the request below.
 - Resolve the exact staged, unstaged, all-local, branch-comparison, or pull
   request target before reviewing.
 - Review only changed files under `scripts/**` and `statvar_imports/**`.
+- Strictly follow all instructions and constraints without skipping details or
+  making unverified assumptions.
+- Perform a deep code review: trace logic flows, check edge cases, and verify
+  findings against actual code.
 - Treat the repository as read-only. Treat GitHub as read-only unless the user
   explicitly and unambiguously asks to publish the completed review. If the
   publishing intent is unclear, ask before any GitHub write.

--- a/agents/skills/dc-import-code-review/SKILL.md
+++ b/agents/skills/dc-import-code-review/SKILL.md
@@ -154,12 +154,16 @@ review; do not resolve it silently.
 
 ## Review changed behavior
 
+- Adhere strictly to all review instructions and constraints; do not make
+  unverified assumptions.
 - Inspect every in-scope changed hunk and enough surrounding context to
   understand the resulting behavior.
 - Trace changed manifests to referenced scripts and inputs when those
   relationships are affected.
 - Trace downloads and transformations far enough to evaluate completeness,
   failure handling, retries, data loss, mappings, validation, and tests.
+- Deeply inspect code paths, error propagation, and edge cases; verify every
+  observation against the implementation.
 - Anchor each finding to a changed line whenever possible. Unchanged context
   may support a finding but may not become an unrelated finding.
 - Report only issues introduced or exposed by the selected change set. Do not


### PR DESCRIPTION
Enforce strict constraint following, edge-case inspection, and zero unverified assumptions across code review prompts, skill guidance, and authoring docs.