### PR TITLE
Update test environment configuration for import diagnostics

### DIFF
--- a/agents/common/config/import-environments.yaml
+++ b/agents/common/config/import-environments.yaml
@@ -25,27 +25,19 @@ environments:
     spanner:
       project: datcom-store
       instance: dc-graph-staging
-      database: dc_graph_1
+      database: dc_graph
 
-  staging:
-    scheduler:
-      project: datcom-ci
-      location: us-central1
-
-    workflow:
-      project: datcom-ci
-      location: us-central1
-      import_workflow: import-automation-workflow
+  # Test environment (sometimes called dev environment, used for testing import changes).
+  # Batch jobs are run directly and outputs are checked in GCS.
+  test:
+    # Scheduler: not configured in test
+    # Workflow: not configured in test
 
     batch:
-      project: datcom-ci
+      project: datcom-infosys-dev
       location: us-central1
 
     gcs:
-      client_project: datcom-ci
-      output_bucket: datcom-ci-test
+      output_bucket: datcom-import-test
 
-    spanner:
-      project: datcom-ci
-      instance: datcom-spanner-test
-      database: dc-test-db
+    # Spanner: not configured in test

--- a/agents/common/scripts/skill_contract_test.py
+++ b/agents/common/scripts/skill_contract_test.py
@@ -401,27 +401,38 @@ class SkillContractTest(unittest.TestCase):
         registry = yaml.safe_load(
             self._read('agents/common/config/import-environments.yaml'))
         skill = self._skill_path.read_text(encoding='utf-8')
-        required_fields = {
+        prod_required_fields = {
             'scheduler': {'project', 'location'},
             'workflow': {'project', 'location', 'import_workflow'},
             'batch': {'project', 'location'},
             'gcs': {'client_project', 'output_bucket'},
             'spanner': {'project', 'instance', 'database'},
         }
+        test_required_fields = {
+            'batch': {'project', 'location'},
+            'gcs': {'output_bucket'},
+        }
 
         self.assertIn('../../common/config/import-environments.yaml', skill)
         self.assertEqual({'default_environment', 'environments'}, set(registry))
         self.assertEqual('prod', registry['default_environment'])
-        self.assertEqual({'prod', 'staging'}, set(registry['environments']))
+        self.assertEqual({'prod', 'test'}, set(registry['environments']))
 
-        for name, environment in registry['environments'].items():
-            with self.subTest(environment=name):
-                self.assertEqual(set(required_fields), set(environment))
-                for section, fields in required_fields.items():
-                    self.assertEqual(fields, set(environment[section]))
-                    for field in fields:
-                        self.assertIsInstance(environment[section][field], str)
-                        self.assertTrue(environment[section][field])
+        prod = registry['environments']['prod']
+        self.assertEqual(set(prod_required_fields), set(prod))
+        for section, fields in prod_required_fields.items():
+            self.assertEqual(fields, set(prod[section]))
+            for field in fields:
+                self.assertIsInstance(prod[section][field], str)
+                self.assertTrue(prod[section][field])
+
+        test = registry['environments']['test']
+        self.assertEqual(set(test_required_fields), set(test))
+        for section, fields in test_required_fields.items():
+            self.assertEqual(fields, set(test[section]))
+            for field in fields:
+                self.assertIsInstance(test[section][field], str)
+                self.assertTrue(test[section][field])
 
 
 class ImportCodeReviewSkillContractTest(unittest.TestCase):

--- a/agents/common/scripts/skill_contract_test.py
+++ b/agents/common/scripts/skill_contract_test.py
@@ -418,8 +418,8 @@ class SkillContractTest(unittest.TestCase):
         self.assertIn('../../common/config/import-environments.yaml', skill)
         self.assertEqual({'default_environment', 'environments'}, set(registry))
         self.assertEqual('prod', registry['default_environment'])
-        self.assertEqual(
-            set(expected_environments), set(registry['environments']))
+        self.assertEqual(set(expected_environments),
+                         set(registry['environments']))
 
         for name, required_fields in expected_environments.items():
             with self.subTest(environment=name):

--- a/agents/common/scripts/skill_contract_test.py
+++ b/agents/common/scripts/skill_contract_test.py
@@ -401,38 +401,35 @@ class SkillContractTest(unittest.TestCase):
         registry = yaml.safe_load(
             self._read('agents/common/config/import-environments.yaml'))
         skill = self._skill_path.read_text(encoding='utf-8')
-        prod_required_fields = {
-            'scheduler': {'project', 'location'},
-            'workflow': {'project', 'location', 'import_workflow'},
-            'batch': {'project', 'location'},
-            'gcs': {'client_project', 'output_bucket'},
-            'spanner': {'project', 'instance', 'database'},
-        }
-        test_required_fields = {
-            'batch': {'project', 'location'},
-            'gcs': {'output_bucket'},
+        expected_environments = {
+            'prod': {
+                'scheduler': {'project', 'location'},
+                'workflow': {'project', 'location', 'import_workflow'},
+                'batch': {'project', 'location'},
+                'gcs': {'client_project', 'output_bucket'},
+                'spanner': {'project', 'instance', 'database'},
+            },
+            'test': {
+                'batch': {'project', 'location'},
+                'gcs': {'output_bucket'},
+            },
         }
 
         self.assertIn('../../common/config/import-environments.yaml', skill)
         self.assertEqual({'default_environment', 'environments'}, set(registry))
         self.assertEqual('prod', registry['default_environment'])
-        self.assertEqual({'prod', 'test'}, set(registry['environments']))
+        self.assertEqual(
+            set(expected_environments), set(registry['environments']))
 
-        prod = registry['environments']['prod']
-        self.assertEqual(set(prod_required_fields), set(prod))
-        for section, fields in prod_required_fields.items():
-            self.assertEqual(fields, set(prod[section]))
-            for field in fields:
-                self.assertIsInstance(prod[section][field], str)
-                self.assertTrue(prod[section][field])
-
-        test = registry['environments']['test']
-        self.assertEqual(set(test_required_fields), set(test))
-        for section, fields in test_required_fields.items():
-            self.assertEqual(fields, set(test[section]))
-            for field in fields:
-                self.assertIsInstance(test[section][field], str)
-                self.assertTrue(test[section][field])
+        for name, required_fields in expected_environments.items():
+            with self.subTest(environment=name):
+                environment = registry['environments'][name]
+                self.assertEqual(set(required_fields), set(environment))
+                for section, fields in required_fields.items():
+                    self.assertEqual(fields, set(environment[section]))
+                    for field in fields:
+                        self.assertIsInstance(environment[section][field], str)
+                        self.assertTrue(environment[section][field])
 
 
 class ImportCodeReviewSkillContractTest(unittest.TestCase):

--- a/agents/skills/dc-import-diagnostics/references/environment-resolution.md
+++ b/agents/skills/dc-import-diagnostics/references/environment-resolution.md
@@ -2,7 +2,7 @@
 
 Use [import environment defaults](../../../common/config/import-environments.yaml) for
 cloud resource settings. Production is the default environment; normalize
-`production` to `prod`. Use `staging` only when requested.
+`production` to `prod`. Normalize `dev` or `test` to `test`. Use `test` only when requested.
 
 ## Resolution order
 

--- a/agents/skills/dc-import-postmortem-doc/SKILL.md
+++ b/agents/skills/dc-import-postmortem-doc/SKILL.md
@@ -76,7 +76,7 @@ failure_category: "<CATEGORY_FROM_TAXONOMY>"
 sub_category: "<SPECIFIC_SUB_CATEGORY>"
 manifest_path: <REPO_RELATIVE_PATH_OR_NULL>
 absolute_import_name: <DIRECTORY_IMPORT_NAME_OR_NULL>
-environment: "<prod|staging>"
+environment: "<prod|test>"
 job_id: <BATCH_JOB_ID_OR_NULL>
 job_uid: <BATCH_JOB_UID_OR_NULL>
 exit_code: <INTEGER_OR_NULL>


### PR DESCRIPTION
### Summary
Updates `import-environments.yaml` to replace the previous `staging` environment with `test` (dev) configuration:
- Configures Batch project to `datcom-infosys-dev`.
- Configures GCS output bucket to `datcom-import-test` (with `client_project` omitted).
- Adds comments noting that `scheduler`, `workflow`, and `spanner` are unconfigured in `test`, as batch jobs are executed directly and outputs inspected in GCS.
- Updates contract test assertions in `skill_contract_test.py` and aligns documentation in `environment-resolution.md` and `dc-import-postmortem-doc/SKILL.md`.

### Testing
- `python agents/common/scripts/skill_contract_test.py` (16/16 passed)
- `python agents/common/scripts/diagnostics_reference_test.py` (7/7 passed)
