### PR TITLE
 Fix provisional node generation logic

### DIFF
--- a/import-automation/executor/scripts/generate_provisional_nodes.py
+++ b/import-automation/executor/scripts/generate_provisional_nodes.py
@@ -44,6 +44,11 @@ flags.DEFINE_string("directory",
                     os.getcwd(),
                     "Directory to scan (default: current working directory)",
                     allow_override=True)
+flags.DEFINE_string(
+    "output_dir",
+    "",
+    "Directory to write output files (default: same as directory)",
+    allow_override=True)
 flags.DEFINE_bool("no_spanner", False, "Skip Spanner check")
 flags.DEFINE_string("spanner_project", "datcom-store", "Spanner project ID")
 flags.DEFINE_string("spanner_instance", "dc-graph-staging",
@@ -102,7 +107,8 @@ def strip_quotes(s):
 
 def check_spanner_nodes(node_ids, project, instance_id, database_id):
     """
-    Checks which of the given node_ids exist in the Spanner Node table.
+    Checks which of the given node_ids exist in the Spanner Node table and
+    have a typeOf predicate in the Edge table.
     
     Args:
         node_ids: A collection of node IDs (strings) to check against Spanner.
@@ -141,7 +147,7 @@ def check_spanner_nodes(node_ids, project, instance_id, database_id):
 
                 try:
                     result = snapshot.execute_sql(
-                        "SELECT subject_id FROM Node WHERE subject_id IN UNNEST(@ids)",
+                        "SELECT DISTINCT subject_id FROM Edge WHERE subject_id IN UNNEST(@ids) AND predicate = 'typeOf'",
                         params={"ids": batch},
                         param_types={
                             "ids":
@@ -158,11 +164,13 @@ def check_spanner_nodes(node_ids, project, instance_id, database_id):
 
     except Exception as e:
         logging.error(f"Failed to connect to Spanner or create snapshot: {e}")
+        raise
 
     return existing_nodes
 
 
 def generate_provisional_nodes(scan_dir,
+                               output_dir=None,
                                no_spanner=False,
                                spanner_project="datcom-store",
                                spanner_instance="dc-graph-staging",
@@ -172,6 +180,7 @@ def generate_provisional_nodes(scan_dir,
     
     Args:
         scan_dir: The local directory containing .mcf files to scan.
+        output_dir: The directory where output files should be written (default: scan_dir).
         no_spanner: If True, skips checking Cloud Spanner for existing nodes.
         spanner_project: Spanner project ID.
         spanner_instance: Spanner instance ID.
@@ -182,7 +191,11 @@ def generate_provisional_nodes(scan_dir,
     """
     start_time = time.time()
     root_dir = os.path.abspath(scan_dir)
-    output_dir = root_dir
+    if output_dir is None or not output_dir:
+        output_dir = root_dir
+    else:
+        output_dir = os.path.abspath(output_dir)
+        os.makedirs(output_dir, exist_ok=True)
 
     defined_nodes = set()
     referenced_properties = set()
@@ -329,10 +342,13 @@ def generate_provisional_nodes(scan_dir,
 
 
 def main(_):
-    output_path = generate_provisional_nodes(FLAGS.directory, FLAGS.no_spanner,
-                                             FLAGS.spanner_project,
-                                             FLAGS.spanner_instance,
-                                             FLAGS.spanner_database)
+    output_path = generate_provisional_nodes(
+        scan_dir=FLAGS.directory,
+        output_dir=FLAGS.output_dir if FLAGS.output_dir else None,
+        no_spanner=FLAGS.no_spanner,
+        spanner_project=FLAGS.spanner_project,
+        spanner_instance=FLAGS.spanner_instance,
+        spanner_database=FLAGS.spanner_database)
     logging.info(f"Generated provisional nodes at: {output_path}")
 
 

--- a/scripts/entities/download.sh
+++ b/scripts/entities/download.sh
@@ -30,6 +30,11 @@ for i in "$@"; do
   esac
 done
 
+if [[ -z "${ENTITY}" || -z "${VERSION}" ]]; then
+  echo "Error: --entity and --version must be non-empty." >&2
+  exit 1
+fi
+
 DIR_NAME="entities"
 BUCKET_NAME="datcom-prod-imports"
 GCS_FOLDER_PREFIX="scripts/entities/${ENTITY}"
@@ -38,4 +43,8 @@ GCS_PATH="gs://${BUCKET_NAME}/${GCS_FOLDER_PREFIX}/${VERSION}"
 echo "Downloading import ${ENTITY} for version ${VERSION} from ${GCS_PATH} to $(pwd)"
 mkdir -p "${ENTITY}"
 gcloud storage cp -r "${GCS_PATH}" "${ENTITY}/" &> copy.log
+if [[ -n "${ENTITY}" && -n "${VERSION}" ]]; then
+  rm -rf "${ENTITY}/${VERSION}"/input[0-9]*
+  rm -rf "${ENTITY}/${VERSION}/source_files"
+fi
 echo "Successfully downloaded ${ENTITY} version ${VERSION}"

--- a/scripts/entities/manifest.json
+++ b/scripts/entities/manifest.json
@@ -11,12 +11,14 @@
                 "./download.sh --entity=Schema",
                 "./process.py --entity=Schema"
             ],
+            "source_files": [
+                "provisional_nodes.mcf"
+            ],
             "import_inputs": [
                 {
-                    "node_mcf": "**/*.mcf*"
+                    "node_mcf": "Schema/**/*.mcf*"
                 }
             ],
-            "source_files": [],
             "config_override": {
                 "invoke_import_validation": true,
                 "invoke_import_tool": true,

--- a/scripts/entities/process.py
+++ b/scripts/entities/process.py
@@ -33,23 +33,33 @@ import generate_provisional_nodes
 FLAGS = flags.FLAGS
 flags.DEFINE_string("entity", "", "Entity type (Schema/Place).")
 flags.DEFINE_string("version", "", "Import version.")
+flags.DEFINE_string(
+    "output_dir", "",
+    "Directory to write output files (default: directory containing manifest.json)."
+)
 
 
-def process(entity_type: str, version: str):
+def process(entity_type: str, version: str, output_dir: str = ""):
     logging.info(f'Processing import {entity_type} for version {version}')
     local_path = os.path.abspath(
         os.path.join(os.path.dirname(__file__), entity_type, version))
 
+    # Default output directory to the folder containing manifest.json (os.path.dirname(__file__))
+    if not output_dir:
+        output_dir = os.path.abspath(os.path.dirname(__file__))
+
     # Local path to data
     logging.info(
-        f'Generating provisional nodes for {entity_type} in {local_path}')
-    generate_provisional_nodes.generate_provisional_nodes(local_path)
+        f'Generating provisional nodes for {entity_type} in {local_path} (output: {output_dir})'
+    )
+    generate_provisional_nodes.generate_provisional_nodes(local_path,
+                                                          output_dir=output_dir)
     return 0
 
 
 def main(_):
     """Runs the code."""
-    process(FLAGS.entity, FLAGS.version)
+    process(FLAGS.entity, FLAGS.version, FLAGS.output_dir)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
We currently check the Node table to find missing nodes but this logic breaks since the import tool existence check also looks for typeOf properties in the Edge table. Once the provisional nodes are generated, the corresponding typeOf Edges are deleted by the following runs and never generated again causing import validation errors from the import tool. This PR checks the Edge table to generate provisional nodes.

Also, updated the manifest so generated provisional nodes are copied to GCS but not included in the current run causing a validation failure for a manual intervention to copy the generated nodes to be copied to the Schema repo.  