### PR TITLE
Skip input upload for Schema

### DIFF
--- a/scripts/entities/manifest.json
+++ b/scripts/entities/manifest.json
@@ -23,7 +23,7 @@
                 "invoke_import_validation": true,
                 "invoke_import_tool": true,
                 "invoke_differ_tool": true,
-                "skip_input_upload": false
+                "skip_input_upload": true
             }
         },
         {


### PR DESCRIPTION
This leads to duplicate files in GCS. provisional_nodes.mcf is copy as part of source files