### PR TITLE
Centralize differ DataFrame column definitions

### DIFF
--- a/tools/import_validation/runner.py
+++ b/tools/import_validation/runner.py
@@ -29,7 +29,7 @@ from validation_config import ValidationConfig
 from report_generator import ReportGenerator
 from validator import Validator
 from result import ValidationResult, ValidationStatus
-from validation_util import filter_dataframe
+from validation_util import DIFFER_COLUMNS, filter_dataframe
 
 _FLAGS = flags.FLAGS
 
@@ -48,7 +48,7 @@ class ValidationRunner:
         self.validation_results = []
         self.data_sources = {
             'stats': pd.DataFrame(),
-            'differ': pd.DataFrame(),
+            'differ': pd.DataFrame(columns=DIFFER_COLUMNS),
             'differ_summary': {},
             'lint': {}
         }
@@ -191,8 +191,7 @@ class ValidationRunner:
                     stats[current_var][diff_type] += 1
 
         if not stats:
-            return pd.DataFrame(
-                columns=['StatVar', 'ADDED', 'DELETED', 'MODIFIED'])
+            return pd.DataFrame(columns=DIFFER_COLUMNS)
 
         rows = []
         for var, counts in stats.items():

--- a/tools/import_validation/runner_test.py
+++ b/tools/import_validation/runner_test.py
@@ -22,6 +22,7 @@ import tempfile
 
 from tools.import_validation.runner import ValidationRunner
 from tools.import_validation.result import ValidationResult, ValidationStatus
+from tools.import_validation.validation_util import DIFFER_COLUMNS
 
 
 class TestValidationRunner(unittest.TestCase):
@@ -72,6 +73,8 @@ class TestValidationRunner(unittest.TestCase):
         runner.run_validations()
 
         # 4. Assert that the correct method was called on the mock
+        self.assertEqual(list(runner.data_sources['differ'].columns),
+                         DIFFER_COLUMNS)
         mock_validator_instance.validate_max_date_latest.assert_called_once()
         # Ensure other methods were NOT called
         mock_validator_instance.validate_deleted_records_count.assert_not_called(

--- a/tools/import_validation/validation_util.py
+++ b/tools/import_validation/validation_util.py
@@ -16,6 +16,8 @@
 import pandas as pd
 import re
 
+DIFFER_COLUMNS = ['StatVar', 'ADDED', 'DELETED', 'MODIFIED']
+
 
 def filter_dataframe(df: pd.DataFrame,
                      dcids: list[str] = None,

--- a/tools/import_validation/validator.py
+++ b/tools/import_validation/validator.py
@@ -25,6 +25,7 @@ sys.path.append(os.path.join(_DATA_DIR, 'util'))
 
 from result import ValidationResult, ValidationStatus
 from counters import Counters
+from validation_util import DIFFER_COLUMNS
 import validator_goldens
 
 
@@ -58,6 +59,8 @@ class Validator:
         try:
             con = duckdb.connect(database=':memory:', read_only=False)
             con.register('stats', stats_df)
+            if differ_df.empty:
+                differ_df = pd.DataFrame(columns=DIFFER_COLUMNS)
             con.register('differ', differ_df)
 
             final_query = f"""

--- a/tools/import_validation/validator_test.py
+++ b/tools/import_validation/validator_test.py
@@ -808,6 +808,15 @@ class TestSQLValidator(unittest.TestCase):
         self.assertEqual(result.status, ValidationStatus.FAILED)
         self.assertEqual(len(result.details['failing_rows']), 2)
 
+    def test_sql_validator_registers_empty_differ_with_expected_columns(self):
+        params = {
+            'query': 'SELECT StatVar, ADDED, DELETED, MODIFIED FROM differ',
+            'condition': 'ADDED >= 0'
+        }
+        result = self.validator.validate_sql(self.stats_df, pd.DataFrame(),
+                                             params)
+        self.assertEqual(result.status, ValidationStatus.PASSED)
+
     def test_sql_validator_invalid_sql(self):
         params = {'query': 'SELEC * FROM stats', 'condition': 'MaxValue <= 100'}
         result = self.validator.validate_sql(self.stats_df, self.differ_df,


### PR DESCRIPTION
 Addresses the follow-up cleanup for DuckDB differ registration:

  - Defines DIFFER_COLUMNS as the shared differ schema.
  - Initializes the runner’s empty differ DataFrame with that schema.
  - Reuses the schema when loading empty differ output and registering an empty DataFrame with DuckDB.
  - Adds regression coverage for missing and empty differ data.

  All 121 tools/import_validation tests pass.