### PR TITLE
Enforce supplemental review guidance in subagents

### DIFF
--- a/agents/skills/dc-import-code-review/SKILL.md
+++ b/agents/skills/dc-import-code-review/SKILL.md
@@ -144,10 +144,11 @@ changed behavior.
 - If the supplemental guidelines remain unavailable for any reason, stop the
   review immediately and report it as blocked. Do not inspect the change set,
   delegate review work, run checks, or publish a review.
-- When delegating, give every review subagent the repository guidelines and the
-  downloaded supplemental guidelines, either as content or through a readable
-  local path. Explicitly require each subagent to read both before inspecting
-  changes, and do not use results that omit confirmation.
+- When delegating, give every review subagent the import code review guidelines
+  and the downloaded supplemental guidelines, either as content or through a
+  readable local path.
+- Require each subagent to state in its response that it read both before
+  inspecting changes. Do not use results that omit this confirmation.
 - Repository guidance and safety rules take precedence.
 
 When any in-scope `manifest.json` changes, also read the current shared

--- a/agents/skills/dc-import-code-review/SKILL.md
+++ b/agents/skills/dc-import-code-review/SKILL.md
@@ -135,14 +135,19 @@ changed behavior.
 
 **CRITICAL: When golden summaries or validation configs are present, you MUST rigorously enforce all validation and freshness rules defined in the guidelines.**
 
-- Load supplemental guidelines with `gcloud storage cat` from
+- Before inspecting the change set or delegating review work, load supplemental
+  guidelines with `gcloud storage cat` from
   `gs://datcom-prod-imports/agents/skills/dc-import-code-review/additional-guidelines.md`.
-- If loading fails because of sandbox or network restrictions, request
+- If loading fails and sandbox or network restrictions may be responsible, request
   permission to rerun the same `gcloud storage cat` command outside the
   sandbox, then retry it.
-- If the retry fails, stop the review immediately and report it as blocked
-  because the supplemental guidelines were unavailable. Do not inspect the
-  change set further, run checks, or publish a review.
+- If the supplemental guidelines remain unavailable for any reason, stop the
+  review immediately and report it as blocked. Do not inspect the change set,
+  delegate review work, run checks, or publish a review.
+- When delegating, give every review subagent the repository guidelines and the
+  downloaded supplemental guidelines, either as content or through a readable
+  local path. Explicitly require each subagent to read both before inspecting
+  changes, and do not use results that omit confirmation.
 - Repository guidance and safety rules take precedence.
 
 When any in-scope `manifest.json` changes, also read the current shared


### PR DESCRIPTION
 ## Summary

  - load supplemental guidelines before inspecting changes or delegating review work
  - block the review if the supplemental guidelines remain unavailable
  - require every review subagent to read and confirm both guideline sets

  ## Tests

  - `python3 /home/rohitrkumar_google_com/.codex/skills/.system/skill-creator/scripts/quick_validate.py agents/skills/dc-import-code-review`
  - `.env/bin/python -m unittest -v agents.common.scripts.skill_contract_test.ImportCodeReviewSkillContractTest`
  - `git diff --check`